### PR TITLE
fix: add context cache for bbs v1 and export document loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ signed_vc*.json
 credentialStatus*.json
 derived_vc*.json
 reveal*.json
+public/context/

--- a/packages/w3c-context/src/context/bbs-v1.json
+++ b/packages/w3c-context/src/context/bbs-v1.json
@@ -1,0 +1,129 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+    "BbsBlsSignature2020": {
+      "@id": "https://w3id.org/security#BbsBlsSignature2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "proofValue": "https://w3id.org/security#proofValue",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "BbsBlsSignatureProof2020": {
+      "@id": "https://w3id.org/security#BbsBlsSignatureProof2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "Bls12381G1Key2020": {
+      "@id": "https://w3id.org/security#Bls12381G1Key2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "controller": {
+          "@id": "https://w3id.org/security#controller",
+          "@type": "@id"
+        },
+        "revoked": {
+          "@id": "https://w3id.org/security#revoked",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "publicKeyBase58": {
+          "@id": "https://w3id.org/security#publicKeyBase58"
+        }
+      }
+    },
+    "Bls12381G2Key2020": {
+      "@id": "https://w3id.org/security#Bls12381G2Key2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "controller": {
+          "@id": "https://w3id.org/security#controller",
+          "@type": "@id"
+        },
+        "revoked": {
+          "@id": "https://w3id.org/security#revoked",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "publicKeyBase58": {
+          "@id": "https://w3id.org/security#publicKeyBase58"
+        }
+      }
+    }
+  }
+}

--- a/packages/w3c-context/src/lib/index.ts
+++ b/packages/w3c-context/src/lib/index.ts
@@ -1,11 +1,12 @@
-import didV1 from '../context/did-v1.json';
-import trContext from '../context/transferable-records-context.json';
-import renderContext from '../context/render-method-context.json';
 import attachmentsContext from '../context/attachments-context.json';
+import bbsV1 from '../context/bbs-v1.json';
 import bolContext from '../context/bill-of-lading.json';
-import invoiceContext from '../context/invoice.json';
 import credentialsV1 from '../context/credentials-v1.json';
 import credentialsV2 from '../context/credentials-v2.json';
+import didV1 from '../context/did-v1.json';
+import invoiceContext from '../context/invoice.json';
+import renderContext from '../context/render-method-context.json';
+import trContext from '../context/transferable-records-context.json';
 import { Document } from './types';
 
 export const DID_V1_URL = 'https://www.w3.org/ns/did/v1';
@@ -24,6 +25,7 @@ export const contexts: { [key: string]: Document } = {
   [DID_V1_URL]: didV1,
   [VC_V1_URL]: credentialsV1,
   [VC_V2_URL]: credentialsV2,
+  [BBS_V1_URL]: bbsV1,
 };
 
 export const trContexts: { [key: string]: Document } = {

--- a/packages/w3c-vc/src/lib/w3c-vc.ts
+++ b/packages/w3c-vc/src/lib/w3c-vc.ts
@@ -142,7 +142,7 @@ export const signCredential = async (
   keyPair: PrivateKeyPair,
   cryptoSuite = 'BbsBlsSignature2020',
   options?: {
-    documentLoader: DocumentLoader;
+    documentLoader?: DocumentLoader;
   },
 ): Promise<SigningResult> => {
   try {
@@ -194,7 +194,7 @@ export const signCredential = async (
 export const verifyCredential = async (
   credential: SignedVerifiableCredential,
   options?: {
-    documentLoader: DocumentLoader;
+    documentLoader?: DocumentLoader;
   },
 ): Promise<VerificationResult> => {
   try {
@@ -258,7 +258,7 @@ export const deriveCredential = async (
   credential: SignedVerifiableCredential,
   revealedAttributes: ContextDocument,
   options?: {
-    documentLoader: DocumentLoader;
+    documentLoader?: DocumentLoader;
   },
 ): Promise<DerivedResult> => {
   try {

--- a/packages/w3c-vc/src/lib/w3c-vc.ts
+++ b/packages/w3c-vc/src/lib/w3c-vc.ts
@@ -141,12 +141,15 @@ export const signCredential = async (
   credential: RawVerifiableCredential,
   keyPair: PrivateKeyPair,
   cryptoSuite = 'BbsBlsSignature2020',
+  options?: {
+    documentLoader: DocumentLoader;
+  },
 ): Promise<SigningResult> => {
   try {
     if (cryptoSuite === 'BbsBlsSignature2020') {
       _checkKeyPair(keyPair);
       _checkCredential(credential, undefined, 'sign');
-      const documentLoader = await getDocumentLoader();
+      const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
 
       const key = new Bls12381G2KeyPair(keyPair as KeyPairOptions);
 
@@ -190,10 +193,13 @@ export const signCredential = async (
  */
 export const verifyCredential = async (
   credential: SignedVerifiableCredential,
+  options?: {
+    documentLoader: DocumentLoader;
+  },
 ): Promise<VerificationResult> => {
   try {
     _checkCredential(credential);
-    const documentLoader = await getDocumentLoader();
+    const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
 
     let verificationResult;
     const proofType = jsonld.getValues(credential, 'proof')[0].type as ProofType;
@@ -251,10 +257,13 @@ export const verifyCredential = async (
 export const deriveCredential = async (
   credential: SignedVerifiableCredential,
   revealedAttributes: ContextDocument,
+  options?: {
+    documentLoader: DocumentLoader;
+  },
 ): Promise<DerivedResult> => {
   try {
     _checkCredential(credential);
-    const documentLoader = await getDocumentLoader();
+    const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
 
     // Generate a derived proof with selective disclosure using the BbsBlsSignatureProof2020 suite
     const derivedProof = await deriveProof(credential, revealedAttributes, {

--- a/scripts/copy-files.sh
+++ b/scripts/copy-files.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+### THIS SCRIPT IS NEEDED TO HOST THE CONTEXT FILES ON "https://trustvc.io/context/<file-name>" THROUGH NETLIFY
+
 # Define the source and destination directories
 SOURCE_DIR="./packages/w3c-context/src/context"
 DEST_DIR="./public/context"


### PR DESCRIPTION
## Summary
What is the background of this pull request?
- Add cache for BBS v1 context
- Expose documentLoader for signCredential, verifyCredential and deriveCredential
