### PR TITLE
feat: status list update for bbs and v2.0

### DIFF
--- a/packages/w3c-credential-status/README.md
+++ b/packages/w3c-credential-status/README.md
@@ -176,8 +176,8 @@ const optionsV2 = {
       type: 'BitstringStatusList', // v2.0 credential subject type
       statusPurpose: purpose,
       encodedList,
-    };
-}
+    },
+};
 
 // Example with ECDSA-SD-2023
 const credentialStatusVCV2_ECDSA = await createCredentialStatusPayload(
@@ -191,7 +191,7 @@ const credentialStatusVCV2_ECDSA = await createCredentialStatusPayload(
 const credentialStatusVCV2_BBS = await createCredentialStatusPayload(
   optionsV2, 
   keyPair, 
-  'BitstringStatusListCredential', // v2.0 credential type
+  'BitstringStatusListCredential', // v2.0 credential type,
   'bbs-2023' // modern cryptosuite
 );
 
@@ -207,8 +207,8 @@ const optionsV1 = {
       type: 'StatusList2021', // v1.1 credential subject type
       statusPurpose: purpose,
       encodedList,
-    };
-}
+    },
+};
 
 const credentialStatusVCV1 = await createCredentialStatusPayload(
   optionsV1, 
@@ -376,7 +376,7 @@ const credentialStatusPayload = await createCredentialStatusPayload(
     },
   },
   keypairData, // Your key pair data
-  'BitstringStatusListCredential'
+  'BitstringStatusListCredential',
   'ecdsa-sd-2023' // Use 'ecdsa-sd-2023' or 'bbs-2023'
 );
 

--- a/packages/w3c-credential-status/README.md
+++ b/packages/w3c-credential-status/README.md
@@ -23,7 +23,7 @@ The revocation or suspension of Verifiable Credentials is achieved by changing t
 - Credential status type: `BitstringStatusListEntry`
 - Credential subject type: `BitstringStatusList`
 
-This module provides functionality to create/update a signed Verifiable Credential (VC) for credential status, using a specified cryptographic suite and key pair. It supports creation of data model v2.0 VC's using modern ECDSA-SD-2023 / BBS-2023 cryptosuites.
+This module provides functionality to create/update a signed Verifiable Credential (VC) for credential status, using a specified cryptographic suite and key pair. It supports modern ECDSA-SD-2023 and BBS-2023 cryptosuites.
 
 ## Table of Contents
 
@@ -214,7 +214,7 @@ const credentialStatusVCV1 = await createCredentialStatusPayload(
   optionsV1, 
   keyPair, 
   'StatusList2021Credential', // v1.1 credential type
-  'BbsBlsSignature2020' // legacy cryptosuite
+  'BbsBlsSignature2020' // ⚠️ DEPRECATED - this will result in error. Use modern cryptosuites
 );
 // Sign the credential status payload
 const { signed, error } = await signCredential(credentialStatusPayload, keypairData);
@@ -411,7 +411,7 @@ const signedCredentialStatusVC = signed;
 > `cryptoSuite (CryptoSuiteName)`: The cryptosuite for signing. Options:
 > - `'ecdsa-sd-2023'` (modern ECDSA-SD-2023 signatures)
 > - `'bbs-2023'` (modern BBS-2023 signatures)
-> - `'BbsBlsSignature2020'` (DEPRECATED: legacy BBS+ signatures, use `'ecdsa-sd-2023'` or `'bbs-2023'` instead)
+> - `'BbsBlsSignature2020'` (⚠️ DEPRECATED: legacy BBS+ signatures, use `'ecdsa-sd-2023'` or `'bbs-2023'` instead)
 
 ### `signCredential`
 

--- a/packages/w3c-credential-status/README.md
+++ b/packages/w3c-credential-status/README.md
@@ -23,7 +23,7 @@ The revocation or suspension of Verifiable Credentials is achieved by changing t
 - Credential status type: `BitstringStatusListEntry`
 - Credential subject type: `BitstringStatusList`
 
-This module provides functionality to create/update a signed Verifiable Credential (VC) for credential status, using a specified cryptographic suite and key pair. It supports both legacy BBS+ signatures and modern ECDSA-SD-2023 cryptosuites.
+This module provides functionality to create/update a signed Verifiable Credential (VC) for credential status, using a specified cryptographic suite and key pair. It supports creation of data model v2.0 VC's using modern ECDSA-SD-2023 / BBS-2023 cryptosuites and legacy BBS+ signature for existing VCs created with data model v1.1 .
 
 ## Table of Contents
 
@@ -63,10 +63,10 @@ npm install @trustvc/w3c-credential-status
 
 ## Features
 
-- **Dual Version Support**: Compatible with both W3C VC Data Model v1.1 and v2.0
-- **Multiple Cryptosuites**: Supports BBS+ (legacy) and ECDSA-SD-2023 (modern) signatures
-- **Flexible Status Types**: Create both `StatusList2021Credential` and `BitstringStatusListCredential`
-- **Backward Compatibility**: Existing v1.1 implementations continue to work
+- **Dual Version Support**: Compatible with W3C VC Data Model v2.0 and backward compatible with existing v1.1
+- **Multiple Cryptosuites**: Supports modern signatures ECDSA-SD-2023 and BBS2023
+- **Status Types**: Creates `BitstringStatusListCredential`
+- **Backward Compatibility**: Existing v1.1 implementations continue to work with StatusList2021Credential
 - Create Credential Status Verifiable Credentials with various cryptographic suites
 - Update revocation status for existing VCs
 
@@ -158,16 +158,48 @@ import { PrivateKeyPair } from '@trustvc/w3c-issuer';
  * - options.credentialSubject (object): The credential subject.
  * - keyPair (PrivateKeyPair): The key pair options for signing
  * - type (VCCredentialStatusType): The type of the credential status VC. 
- *   Options: 'StatusList2021Credential' (v1.1) or 'BitstringStatusListCredential' (v2.0)
+ *   Options: 'BitstringStatusListCredential' (v2.0) or 'StatusList2021Credential' (v1.1 - only for existing VCs with resolvable hostingUrl)
  * - cryptoSuite (string): The cryptosuite to be used for signing. 
- *   Options: 'BbsBlsSignature2020' (legacy) or 'ecdsa-sd-2023' (modern)
+ *   Options: 'ecdsa-sd-2023', or 'bbs-2023' (for v2.0) or 'BbsBlsSignature2020' (for v1.1 - only for existing VCs with resolvable hostingUrl)
  *
  * Returns:
  * - A Promise that resolves to:
  * - RawCredentialStatusVC: The signed credential status Verifiable Credential.
  */
 
-// Example for W3C VC Data Model v1.1 (legacy)
+
+// Example for W3C VC Data Model v2.0 (modern)
+const optionsV2 = {
+    id: hostingUrl,
+    credentialSubject: {
+      id: `${hostingUrl}#list`,
+      type: 'BitstringStatusList', // v2.0 credential subject type
+      statusPurpose: purpose,
+      encodedList,
+    };
+}
+
+// Example with ECDSA-SD-2023
+const credentialStatusVCV2_ECDSA = await createCredentialStatusPayload(
+  optionsV2, 
+  keyPair, 
+  'BitstringStatusListCredential', // v2.0 credential type
+  'ecdsa-sd-2023' // modern cryptosuite
+);
+
+// Example with BBS-2023
+const credentialStatusVCV2_BBS = await createCredentialStatusPayload(
+  optionsV2, 
+  keyPair, 
+  'BitstringStatusListCredential', // v2.0 credential type
+  'bbs-2023' // modern cryptosuite
+);
+
+console.log('Credential Status VC (ECDSA):', credentialStatusVCV2_ECDSA);
+console.log('Credential Status VC (BBS):', credentialStatusVCV2_BBS);
+
+
+// Example for W3C VC Data Model v1.1 (legacy) - works with existing v1.1 where the hostingUrl is resolvable
 const optionsV1 = {
     id: hostingUrl,
     credentialSubject: {
@@ -184,27 +216,6 @@ const credentialStatusVCV1 = await createCredentialStatusPayload(
   'StatusList2021Credential', // v1.1 credential type
   'BbsBlsSignature2020' // legacy cryptosuite
 );
-
-// Example for W3C VC Data Model v2.0 (modern)
-const optionsV2 = {
-    id: hostingUrl,
-    credentialSubject: {
-      id: `${hostingUrl}#list`,
-      type: 'BitstringStatusList', // v2.0 credential subject type
-      statusPurpose: purpose,
-      encodedList,
-    };
-}
-
-const credentialStatusVCV2 = await createCredentialStatusPayload(
-  optionsV2, 
-  keyPair, 
-  'BitstringStatusListCredential', // v2.0 credential type
-  'ecdsa-sd-2023' // modern cryptosuite
-);
-
-console.log('Credential Status VC:', credentialStatusVCV2);
-
 // Sign the credential status payload
 const { signed, error } = await signCredential(credentialStatusPayload, keypairData);
 
@@ -215,45 +226,6 @@ if (error) {
 const signedCredentialStatusVC = signed;
 
 ```
-
-<details>
-  <summary>signCredential Result (v1.1 with BBS+)</summary>
-
-```js
-Signed Credential: {
-  '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    'https://w3c-ccg.github.io/citizenship-vocab/contexts/citizenship-v1.jsonld',
-    'https://w3id.org/security/bbs/v1',
-    'https://w3id.org/vc/status-list/2021/v1'
-  ],
-  credentialStatus: {
-    id: 'https://trustvc.github.io/did/credentials/statuslist/1#1',
-    statusListCredential: 'https://trustvc.github.io/did/credentials/statuslist/1',
-    statusListIndex: '1',
-    statusPurpose: 'revocation',
-    type: 'StatusList2021Entry'
-  },
-  issuanceDate: '2024-04-01T12:19:52Z',
-  credentialSubject: {
-    id: 'did:example:b34ca6cd37bbf23',
-    type: [ 'Person' ],
-    name: 'TrustVC'
-  },
-  expirationDate: '2029-12-03T12:19:52Z',
-  issuer: 'did:web:trustvc.github.io:did:1',
-  type: [ 'VerifiableCredential' ],
-  proof: {
-    type: 'BbsBlsSignature2020',
-    created: '2024-10-02T09:04:07Z',
-    proofPurpose: 'assertionMethod',
-    proofValue: 'tissP5pJF1q4txCMWNZI5LgwhXMWrLI8675ops8FwlQE/zBUQnVO9Iey505MjkNDD5GdmQmnb6+RUKkLVGEJLIJrKQXlU3Xr4DlMW7ShH/sIpuvZoobGs/0hw/B5agXz8cVWfnDGWtDYciVh0rwQvg==',
-    verificationMethod: 'did:web:trustvc.github.io:did:1#keys-1'
-  }
-}
-```
-
-</details>
 
 <details>
   <summary>signCredential Result (v2.0 with ECDSA-SD-2023)</summary>
@@ -287,6 +259,82 @@ Signed Credential: {
     proofPurpose: 'assertionMethod',
     proofValue: 'u2V0AhVhAip...',
     verificationMethod: 'did:web:trustvc.github.io:did:1#multikey-1'
+  }
+}
+```
+
+</details>
+
+<details>
+  <summary>signCredential Result (v2.0 with BBS-2023)</summary>
+
+```js
+Signed Credential: {
+  '@context': [
+    'https://www.w3.org/ns/credentials/v2',
+    'https://w3id.org/security/data-integrity/v2'
+  ],
+  credentialStatus: {
+    id: 'https://trustvc.github.io/did/credentials/statuslist/1#1',
+    type: 'BitstringStatusListEntry',
+    statusPurpose: 'revocation',
+    statusListIndex: '10',
+    statusListCredential: 'https://trustvc.github.io/did/credentials/statuslist/1'
+  },
+  validFrom: '2024-04-01T12:19:52Z',
+  credentialSubject: {
+    id: 'did:example:b34ca6cd37bbf23',
+    type: [ 'Person' ],
+    name: 'TrustVC'
+  },
+  validUntil: '2029-12-03T12:19:52Z',
+  issuer: 'did:web:trustvc.github.io:did:1',
+  type: [ 'VerifiableCredential' ],
+  proof: {
+    type: 'DataIntegrityProof',
+    cryptosuite: 'bbs-2023',
+    proofPurpose: 'assertionMethod',
+    proofValue: 'u2V0ChVhQi0FELn9kYULQF...',
+    verificationMethod: 'did:web:trustvc.github.io:did:1#multikey-2'
+  }
+}
+```
+
+</details>
+
+<details>
+  <summary>signCredential Result (v1.1 with BBS+) Legacy</summary>
+
+```js
+Signed Credential: {
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://w3c-ccg.github.io/citizenship-vocab/contexts/citizenship-v1.jsonld',
+    'https://w3id.org/security/bbs/v1',
+    'https://w3id.org/vc/status-list/2021/v1'
+  ],
+  credentialStatus: {
+    id: 'https://trustvc.github.io/did/credentials/statuslist/1#1',
+    statusListCredential: 'https://trustvc.github.io/did/credentials/statuslist/1',
+    statusListIndex: '1',
+    statusPurpose: 'revocation',
+    type: 'StatusList2021Entry'
+  },
+  issuanceDate: '2024-04-01T12:19:52Z',
+  credentialSubject: {
+    id: 'did:example:b34ca6cd37bbf23',
+    type: [ 'Person' ],
+    name: 'TrustVC'
+  },
+  expirationDate: '2029-12-03T12:19:52Z',
+  issuer: 'did:web:trustvc.github.io:did:1',
+  type: [ 'VerifiableCredential' ],
+  proof: {
+    type: 'BbsBlsSignature2020',
+    created: '2024-10-02T09:04:07Z',
+    proofPurpose: 'assertionMethod',
+    proofValue: 'tissP5pJF1q4txCMWNZI5LgwhXMWrLI8675ops8FwlQE/zBUQnVO9Iey505MjkNDD5GdmQmnb6+RUKkLVGEJLIJrKQXlU3Xr4DlMW7ShH/sIpuvZoobGs/0hw/B5agXz8cVWfnDGWtDYciVh0rwQvg==',
+    verificationMethod: 'did:web:trustvc.github.io:did:1#keys-1'
   }
 }
 ```
@@ -356,20 +404,19 @@ After updating the status list, encode it and create a signed credential status 
 // Encode the updated status list
 const encodedList = await statusList.encode();
 
-// Create the credential status payload (v1.1 example)
 const credentialStatusPayload = await createCredentialStatusPayload(
   {
     id: hostingUrl,
     credentialSubject: {
       id: `${hostingUrl}#list`,
-      type: 'StatusList2021', // Use 'BitstringStatusList' for v2.0
+      type: 'BitstringStatusList',
       statusPurpose: purpose,
       encodedList,
     },
   },
   keypairData, // Your key pair data
-  'StatusList2021Credential', // Use 'BitstringStatusListCredential' for v2.0
-  'BbsBlsSignature2020' // Use 'ecdsa-sd-2023' for modern cryptosuite
+  'BitstringStatusListCredential'
+  'ecdsa-sd-2023' // Use 'ecdsa-sd-2023' or 'bbs-2023'
 );
 
 // Sign the credential status payload
@@ -388,7 +435,7 @@ const signedCredentialStatusVC = signed;
 
 ### `createCredentialStatusPayload`
 
-> Creates a credential status payload for both W3C VC Data Model v1.1 and v2.0.
+> Creates a credential status payload for W3C VC Data v2.0 and existing v1.1 VC with resolvable hostingUrl. 
 >
 > #### Parameters:
 >
@@ -397,12 +444,13 @@ const signedCredentialStatusVC = signed;
 > `keypairData (object)`: The key pair data used for signing.
 >
 > `credentialType (VCCredentialStatusType)`: The type of credential. Options:
-> - `'StatusList2021Credential'` (v1.1 legacy)
 > - `'BitstringStatusListCredential'` (v2.0 modern)
+> - `'StatusList2021Credential'` (v1.1 legacy)
 >
 > `cryptoSuite (CryptoSuiteName)`: The cryptosuite for signing. Options:
-> - `'BbsBlsSignature2020'` (legacy BBS+ signatures)
 > - `'ecdsa-sd-2023'` (modern ECDSA-SD-2023 signatures)
+> - `'bbs-2023'` (modern BBS-2023 signatures)
+> - `'BbsBlsSignature2020'` (legacy BBS+ signatures)
 
 ### `signCredential`
 
@@ -474,10 +522,10 @@ To migrate from W3C VC Data Model v1.1 to v2.0:
    - `StatusList2021` → `BitstringStatusList`
 
 2. **Update cryptosuite:**
-   - `BbsBlsSignature2020` → `ecdsa-sd-2023`
+   - `BbsBlsSignature2020` → `ecdsa-sd-2023` or `bbs-2023`
 
 3. **Update key pair format:**
-   - Legacy BLS keys → Modern ECDSA multikey format
+   - Legacy BLS keys → Modern multikey format (ECDSA or BBS2023)
 
 4. **Update contexts:**
    - v1.1 contexts → v2.0 contexts (handled automatically)

--- a/packages/w3c-credential-status/README.md
+++ b/packages/w3c-credential-status/README.md
@@ -23,7 +23,7 @@ The revocation or suspension of Verifiable Credentials is achieved by changing t
 - Credential status type: `BitstringStatusListEntry`
 - Credential subject type: `BitstringStatusList`
 
-This module provides functionality to create/update a signed Verifiable Credential (VC) for credential status, using a specified cryptographic suite and key pair. It supports creation of data model v2.0 VC's using modern ECDSA-SD-2023 / BBS-2023 cryptosuites and legacy BBS+ signature for existing VCs created with data model v1.1 .
+This module provides functionality to create/update a signed Verifiable Credential (VC) for credential status, using a specified cryptographic suite and key pair. It supports creation of data model v2.0 VC's using modern ECDSA-SD-2023 / BBS-2023 cryptosuites.
 
 ## Table of Contents
 
@@ -63,10 +63,10 @@ npm install @trustvc/w3c-credential-status
 
 ## Features
 
-- **Dual Version Support**: Compatible with W3C VC Data Model v2.0 and backward compatible with existing v1.1
+- **Version Support**: Compatible with both W3C VC Data Model v1.1 and v2.0
 - **Multiple Cryptosuites**: Supports modern signatures ECDSA-SD-2023 and BBS2023
-- **Status Types**: Creates `BitstringStatusListCredential`
-- **Backward Compatibility**: Existing v1.1 implementations continue to work with StatusList2021Credential
+- **Flexible Status Types**: Create both `StatusList2021Credential` and `BitstringStatusListCredential`
+- **Backward Compatibility**: Existing v1.1 implementations continue to work
 - Create Credential Status Verifiable Credentials with various cryptographic suites
 - Update revocation status for existing VCs
 
@@ -158,9 +158,9 @@ import { PrivateKeyPair } from '@trustvc/w3c-issuer';
  * - options.credentialSubject (object): The credential subject.
  * - keyPair (PrivateKeyPair): The key pair options for signing
  * - type (VCCredentialStatusType): The type of the credential status VC. 
- *   Options: 'BitstringStatusListCredential' (v2.0) or 'StatusList2021Credential' (v1.1 - only for existing VCs with resolvable hostingUrl)
+ *   Options: 'StatusList2021Credential' (v1.1) or 'BitstringStatusListCredential' (v2.0)
  * - cryptoSuite (string): The cryptosuite to be used for signing. 
- *   Options: 'ecdsa-sd-2023', or 'bbs-2023' (for v2.0) or 'BbsBlsSignature2020' (for v1.1 - only for existing VCs with resolvable hostingUrl)
+ *   Options: 'ecdsa-sd-2023', or 'bbs-2023'
  *
  * Returns:
  * - A Promise that resolves to:
@@ -199,7 +199,7 @@ console.log('Credential Status VC (ECDSA):', credentialStatusVCV2_ECDSA);
 console.log('Credential Status VC (BBS):', credentialStatusVCV2_BBS);
 
 
-// Example for W3C VC Data Model v1.1 (legacy) - works with existing v1.1 where the hostingUrl is resolvable
+// Example for W3C VC Data Model v1.1 (legacy)
 const optionsV1 = {
     id: hostingUrl,
     credentialSubject: {
@@ -302,45 +302,6 @@ Signed Credential: {
 
 </details>
 
-<details>
-  <summary>signCredential Result (v1.1 with BBS+) Legacy</summary>
-
-```js
-Signed Credential: {
-  '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    'https://w3c-ccg.github.io/citizenship-vocab/contexts/citizenship-v1.jsonld',
-    'https://w3id.org/security/bbs/v1',
-    'https://w3id.org/vc/status-list/2021/v1'
-  ],
-  credentialStatus: {
-    id: 'https://trustvc.github.io/did/credentials/statuslist/1#1',
-    statusListCredential: 'https://trustvc.github.io/did/credentials/statuslist/1',
-    statusListIndex: '1',
-    statusPurpose: 'revocation',
-    type: 'StatusList2021Entry'
-  },
-  issuanceDate: '2024-04-01T12:19:52Z',
-  credentialSubject: {
-    id: 'did:example:b34ca6cd37bbf23',
-    type: [ 'Person' ],
-    name: 'TrustVC'
-  },
-  expirationDate: '2029-12-03T12:19:52Z',
-  issuer: 'did:web:trustvc.github.io:did:1',
-  type: [ 'VerifiableCredential' ],
-  proof: {
-    type: 'BbsBlsSignature2020',
-    created: '2024-10-02T09:04:07Z',
-    proofPurpose: 'assertionMethod',
-    proofValue: 'tissP5pJF1q4txCMWNZI5LgwhXMWrLI8675ops8FwlQE/zBUQnVO9Iey505MjkNDD5GdmQmnb6+RUKkLVGEJLIJrKQXlU3Xr4DlMW7ShH/sIpuvZoobGs/0hw/B5agXz8cVWfnDGWtDYciVh0rwQvg==',
-    verificationMethod: 'did:web:trustvc.github.io:did:1#keys-1'
-  }
-}
-```
-
-</details>
-
 ---
 
 ### 2. Update revocation status for existing VC
@@ -435,7 +396,7 @@ const signedCredentialStatusVC = signed;
 
 ### `createCredentialStatusPayload`
 
-> Creates a credential status payload for W3C VC Data v2.0 and existing v1.1 VC with resolvable hostingUrl. 
+> Creates a credential status payload for both W3C VC Data Model v1.1 and v2.0. 
 >
 > #### Parameters:
 >
@@ -450,7 +411,7 @@ const signedCredentialStatusVC = signed;
 > `cryptoSuite (CryptoSuiteName)`: The cryptosuite for signing. Options:
 > - `'ecdsa-sd-2023'` (modern ECDSA-SD-2023 signatures)
 > - `'bbs-2023'` (modern BBS-2023 signatures)
-> - `'BbsBlsSignature2020'` (legacy BBS+ signatures)
+> - `'BbsBlsSignature2020'` (DEPRECATED: legacy BBS+ signatures, use `'ecdsa-sd-2023'` or `'bbs-2023'` instead)
 
 ### `signCredential`
 

--- a/packages/w3c-credential-status/src/lib/index.test.ts
+++ b/packages/w3c-credential-status/src/lib/index.test.ts
@@ -4,10 +4,8 @@ import {
   Bbs2023PrivateKeyPair,
   VerificationType,
 } from '@trustvc/w3c-issuer';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createCredentialStatusPayload } from './index';
-import * as utils from './utils';
-import { VC_V1_URL } from '@trustvc/w3c-context';
 
 const BLS_KEY_PAIR: BBSPrivateKeyPair = {
   id: 'did:web:trustvc.github.io:did:1#keys-1',
@@ -60,6 +58,41 @@ describe('w3c-credential-status', () => {
       ).rejects.toThrowError(
         'BbsBlsSignature2020 is no longer supported. Please use the latest cryptosuite versions instead.',
       );
+    });
+
+    it('should create a credential status VC with ECDSA-SD-2023 and v1.1 context', async () => {
+      const credentialStatusPayload = await createCredentialStatusPayload(
+        {
+          id: 'https://example.com/credentials/3732',
+          credentialSubject: {
+            type: 'StatusList2021',
+            id: 'https://example.com/credentials/status/3#list',
+            statusPurpose: 'revocation',
+            encodedList: 'encodedList',
+          },
+        },
+        ECDSA_SD_KEY_PAIR,
+        'StatusList2021Credential',
+        'ecdsa-sd-2023',
+      );
+
+      expect(credentialStatusPayload).toMatchObject({
+        '@context': [
+          'https://www.w3.org/2018/credentials/v1',
+          'https://w3id.org/security/data-integrity/v2',
+          'https://w3id.org/vc/status-list/2021/v1',
+        ],
+        credentialSubject: {
+          encodedList: 'encodedList',
+          id: 'https://example.com/credentials/status/3#list',
+          statusPurpose: 'revocation',
+          type: 'StatusList2021',
+        },
+        issuanceDate: expect.any(String),
+        issuer: 'did:web:trustvc.github.io:did:1',
+        type: ['VerifiableCredential', 'StatusList2021Credential'],
+        validFrom: expect.any(String),
+      });
     });
 
     it('should create a credential status VC with ECDSA-SD-2023 and v2.0 context', async () => {

--- a/packages/w3c-credential-status/src/lib/index.test.ts
+++ b/packages/w3c-credential-status/src/lib/index.test.ts
@@ -1,10 +1,13 @@
 import {
   BBSPrivateKeyPair,
   EcdsaSd2023PrivateKeyPair,
+  Bbs2023PrivateKeyPair,
   VerificationType,
 } from '@trustvc/w3c-issuer';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createCredentialStatusPayload } from './index';
+import * as utils from './utils';
+import { VC_V1_URL } from '@trustvc/w3c-context';
 
 const BLS_KEY_PAIR: BBSPrivateKeyPair = {
   id: 'did:web:trustvc.github.io:did:1#keys-1',
@@ -25,9 +28,65 @@ const ECDSA_SD_KEY_PAIR: EcdsaSd2023PrivateKeyPair = {
   secretKeyMultibase: 'z42tmUXTVn3n9BihE6NhdMpvVBTnFTgmb6fw18o5Ud6puhRW',
 };
 
+const BBS2023_KEY_PAIR: Bbs2023PrivateKeyPair = {
+  '@context': 'https://w3id.org/security/multikey/v1',
+  id: 'did:web:trustvc.github.io:did:1#multikey-2',
+  type: VerificationType.Multikey,
+  controller: 'did:web:trustvc.github.io:did:1',
+  publicKeyMultibase:
+    'zUC75kRac7BdtjawFUxowfgD6mzqnRHFxAfMDaBynebdYgakviQkPS1KNJEw7uGWqj91H3hSE4pTERb3EZKLgKXjpqHWrN8dyE8SKyPBE3k7kUGjBNAqJoNGgUzqUW3DSaWrcNr',
+  secretKeyMultibase:
+    'zrv1rbvMrsjWcLvfhAKhky5MwFMYoz9WdG9p7YGgUA3eL6z5U3owcX7Tk1P2MJseP8CnZ9AhUsj7HTKTrnB6FNkvEL2',
+};
+
 describe('w3c-credential-status', () => {
   describe('createCredentialStatusVC', () => {
-    it('should create a credential status VC successfully with BLS cryptosuite', async () => {
+    it('Should throw error when trying to create new VC with BLS cryptosuite', async () => {
+      await expect(
+        createCredentialStatusPayload(
+          {
+            id: 'https://example.com/credentials/3732',
+            credentialSubject: {
+              type: 'BitstringStatusList',
+              id: 'https://example.com/credentials/status/3#list',
+              statusPurpose: 'revocation',
+              encodedList: 'encodedList',
+            },
+          },
+          BLS_KEY_PAIR,
+          'BitstringStatusListCredential',
+          'BbsBlsSignature2020',
+        ),
+      ).rejects.toThrowError(
+        'BbsBlsSignature2020 is no longer supported. Please use the latest cryptosuite versions instead.',
+      );
+    });
+
+    it('should throw error if url does not resolve for existing v1.1 signed using BbsBlsSignature2020', async () => {
+      await expect(
+        createCredentialStatusPayload(
+          {
+            id: 'https://example.com/credentials/3732',
+            credentialSubject: {
+              type: 'StatusList2021',
+              id: 'https://example.com/credentials/status/3#list',
+              statusPurpose: 'revocation',
+              encodedList: 'encodedList',
+            },
+          },
+          BLS_KEY_PAIR,
+          'StatusList2021Credential',
+          'BbsBlsSignature2020',
+        ),
+      ).rejects.toThrowError(
+        'Credential Status VC not found. For creating new VCs, please use BitstringStatusListCredential with modern cryptosuite.',
+      );
+    });
+
+    it('should allow to re create an existing credential status VC successfully with BLS cryptosuite', async () => {
+      vi.spyOn(utils, 'validateCredentialStatus').mockResolvedValueOnce({
+        '@context': [VC_V1_URL],
+      } as any);
       const credentialStatusPayload = await createCredentialStatusPayload(
         {
           id: 'https://example.com/credentials/3732',
@@ -39,47 +98,14 @@ describe('w3c-credential-status', () => {
           },
         },
         BLS_KEY_PAIR,
+        'StatusList2021Credential',
+        'BbsBlsSignature2020',
       );
 
       expect(credentialStatusPayload).toMatchObject({
         '@context': [
           'https://www.w3.org/2018/credentials/v1',
           'https://w3id.org/security/bbs/v1',
-          'https://w3id.org/vc/status-list/2021/v1',
-        ],
-        credentialSubject: {
-          encodedList: 'encodedList',
-          id: 'https://example.com/credentials/status/3#list',
-          statusPurpose: 'revocation',
-          type: 'StatusList2021',
-        },
-        issuanceDate: expect.any(String),
-        issuer: 'did:web:trustvc.github.io:did:1',
-        type: ['VerifiableCredential', 'StatusList2021Credential'],
-        validFrom: expect.any(String),
-      });
-    });
-
-    it('should create a credential status VC with ECDSA-SD-2023 and v1.1 context', async () => {
-      const credentialStatusPayload = await createCredentialStatusPayload(
-        {
-          id: 'https://example.com/credentials/3732',
-          credentialSubject: {
-            type: 'StatusList2021',
-            id: 'https://example.com/credentials/status/3#list',
-            statusPurpose: 'revocation',
-            encodedList: 'encodedList',
-          },
-        },
-        ECDSA_SD_KEY_PAIR,
-        'StatusList2021Credential',
-        'ecdsa-sd-2023',
-      );
-
-      expect(credentialStatusPayload).toMatchObject({
-        '@context': [
-          'https://www.w3.org/2018/credentials/v1',
-          'https://w3id.org/security/data-integrity/v2',
           'https://w3id.org/vc/status-list/2021/v1',
         ],
         credentialSubject: {
@@ -109,6 +135,42 @@ describe('w3c-credential-status', () => {
         ECDSA_SD_KEY_PAIR,
         'BitstringStatusListCredential',
         'ecdsa-sd-2023',
+      );
+
+      expect(credentialStatusPayload).toMatchObject({
+        '@context': [
+          'https://www.w3.org/ns/credentials/v2',
+          'https://w3id.org/security/data-integrity/v2',
+        ],
+        credentialSubject: {
+          encodedList: 'encodedList',
+          id: 'https://example.com/credentials/status/3#list',
+          statusPurpose: 'revocation',
+          type: 'BitstringStatusList',
+        },
+        issuer: 'did:web:trustvc.github.io:did:1',
+        type: ['VerifiableCredential', 'BitstringStatusListCredential'],
+        validFrom: expect.any(String),
+      });
+
+      // Explicitly verify that issuanceDate is not present in v2.0
+      expect(credentialStatusPayload).not.toHaveProperty('issuanceDate');
+    });
+
+    it('should create a credential status VC with BBS-2023 and v2.0 context', async () => {
+      const credentialStatusPayload = await createCredentialStatusPayload(
+        {
+          id: 'https://example.com/credentials/3732',
+          credentialSubject: {
+            type: 'BitstringStatusList',
+            id: 'https://example.com/credentials/status/3#list',
+            statusPurpose: 'revocation',
+            encodedList: 'encodedList',
+          },
+        },
+        BBS2023_KEY_PAIR,
+        'BitstringStatusListCredential',
+        'bbs-2023',
       );
 
       expect(credentialStatusPayload).toMatchObject({

--- a/packages/w3c-credential-status/src/lib/index.test.ts
+++ b/packages/w3c-credential-status/src/lib/index.test.ts
@@ -62,65 +62,6 @@ describe('w3c-credential-status', () => {
       );
     });
 
-    it('should throw error if url does not resolve for existing v1.1 signed using BbsBlsSignature2020', async () => {
-      await expect(
-        createCredentialStatusPayload(
-          {
-            id: 'https://example.com/credentials/3732',
-            credentialSubject: {
-              type: 'StatusList2021',
-              id: 'https://example.com/credentials/status/3#list',
-              statusPurpose: 'revocation',
-              encodedList: 'encodedList',
-            },
-          },
-          BLS_KEY_PAIR,
-          'StatusList2021Credential',
-          'BbsBlsSignature2020',
-        ),
-      ).rejects.toThrowError(
-        'Credential Status VC not found. For creating new VCs, please use BitstringStatusListCredential with modern cryptosuite.',
-      );
-    });
-
-    it('should allow to re create an existing credential status VC successfully with BLS cryptosuite', async () => {
-      vi.spyOn(utils, 'validateCredentialStatus').mockResolvedValueOnce({
-        '@context': [VC_V1_URL],
-      } as any);
-      const credentialStatusPayload = await createCredentialStatusPayload(
-        {
-          id: 'https://example.com/credentials/3732',
-          credentialSubject: {
-            type: 'StatusList2021',
-            id: 'https://example.com/credentials/status/3#list',
-            statusPurpose: 'revocation',
-            encodedList: 'encodedList',
-          },
-        },
-        BLS_KEY_PAIR,
-        'StatusList2021Credential',
-        'BbsBlsSignature2020',
-      );
-
-      expect(credentialStatusPayload).toMatchObject({
-        '@context': [
-          'https://www.w3.org/2018/credentials/v1',
-          'https://w3id.org/security/bbs/v1',
-          'https://w3id.org/vc/status-list/2021/v1',
-        ],
-        credentialSubject: {
-          encodedList: 'encodedList',
-          id: 'https://example.com/credentials/status/3#list',
-          statusPurpose: 'revocation',
-          type: 'StatusList2021',
-        },
-        issuanceDate: expect.any(String),
-        issuer: 'did:web:trustvc.github.io:did:1',
-        type: ['VerifiableCredential', 'StatusList2021Credential'],
-        validFrom: expect.any(String),
-      });
-    });
-
     it('should create a credential status VC with ECDSA-SD-2023 and v2.0 context', async () => {
       const credentialStatusPayload = await createCredentialStatusPayload(
         {

--- a/packages/w3c-credential-status/src/lib/index.test.ts
+++ b/packages/w3c-credential-status/src/lib/index.test.ts
@@ -12,7 +12,7 @@ const BLS_KEY_PAIR: BBSPrivateKeyPair = {
   type: VerificationType.Bls12381G2Key2020,
   controller: 'did:web:trustvc.github.io:did:1',
   seedBase58: 'GWP69tmSWJjqC1RoJ27FehcVqkVyeYAz6h5ABwoNSNdS',
-  privateKeyBase58: '4LDU56PUhA9ZEutnR1qCWQnUhtLtpLu2EHSq4h1o7vtF',
+  privateKeyBase58: 'privateKeyBase58',
   publicKeyBase58:
     'oRfEeWFresvhRtXCkihZbxyoi2JER7gHTJ5psXhHsdCoU1MttRMi3Yp9b9fpjmKh7bMgfWKLESiK2YovRd8KGzJsGuamoAXfqDDVhckxuc9nmsJ84skCSTijKeU4pfAcxeJ',
 };
@@ -23,7 +23,7 @@ const ECDSA_SD_KEY_PAIR: EcdsaSd2023PrivateKeyPair = {
   type: VerificationType.Multikey,
   controller: 'did:web:trustvc.github.io:did:1',
   publicKeyMultibase: 'zDnaemDNwi4G5eTzGfRooFFu5Kns3be6yfyVNtiaMhWkZbwtc',
-  secretKeyMultibase: 'z42tmUXTVn3n9BihE6NhdMpvVBTnFTgmb6fw18o5Ud6puhRW',
+  secretKeyMultibase: 'secretKeyMultibase',
 };
 
 const BBS2023_KEY_PAIR: Bbs2023PrivateKeyPair = {
@@ -33,8 +33,7 @@ const BBS2023_KEY_PAIR: Bbs2023PrivateKeyPair = {
   controller: 'did:web:trustvc.github.io:did:1',
   publicKeyMultibase:
     'zUC75kRac7BdtjawFUxowfgD6mzqnRHFxAfMDaBynebdYgakviQkPS1KNJEw7uGWqj91H3hSE4pTERb3EZKLgKXjpqHWrN8dyE8SKyPBE3k7kUGjBNAqJoNGgUzqUW3DSaWrcNr',
-  secretKeyMultibase:
-    'zrv1rbvMrsjWcLvfhAKhky5MwFMYoz9WdG9p7YGgUA3eL6z5U3owcX7Tk1P2MJseP8CnZ9AhUsj7HTKTrnB6FNkvEL2',
+  secretKeyMultibase: 'secretKeyMultibase',
 };
 
 describe('w3c-credential-status', () => {

--- a/packages/w3c-credential-status/src/lib/index.ts
+++ b/packages/w3c-credential-status/src/lib/index.ts
@@ -22,6 +22,7 @@ import {
 import {
   assertCredentialStatusStatusListType,
   getValidFromDateFromCredentialStatusVC,
+  validateCredentialStatus,
 } from './utils';
 
 export const VCCredentialStatusTypeToVCCredentialSubjectType: Record<
@@ -38,18 +39,19 @@ export const VCCredentialStatusTypeToVCCredentialSubjectType: Record<
  * @param {string} options.id - The ID of the credential.
  * @param {object} options.credentialSubject - The credential subject.
  * @param {PrivateKeyPair} keyPair - The key pair options for signing.
- * @param {VCCredentialStatusType} type - The type of the credential status VC. Defaults to 'StatusList2021Credential'.
- * @param {CryptoSuiteName} cryptoSuite - The cryptosuite to be used for signing. Defaults to 'BbsBlsSignature2020'.
+ * @param {VCCredentialStatusType} type - The type of the credential status VC. Defaults to 'BitstringStatusListCredential'.
+ * @param {CryptoSuiteName} cryptoSuite - The cryptosuite to be used for signing. Defaults to 'ecdsa-sd-2023'.
  * @returns {Promise<RawCredentialStatusVC>}
  */
 export const createCredentialStatusPayload = async (
   options: CreateVCCredentialStatusOptions,
   keyPair: PrivateKeyPair,
-  type: VCCredentialStatusType = 'StatusList2021Credential',
-  cryptoSuite: CryptoSuiteName = 'BbsBlsSignature2020',
+  type: VCCredentialStatusType = 'BitstringStatusListCredential',
+  cryptoSuite: CryptoSuiteName = 'ecdsa-sd-2023',
 ): Promise<RawCredentialStatusVC> => {
   try {
     const { id, credentialSubject } = options;
+    await validateCredentialStatus(options, type, cryptoSuite);
 
     switch (type) {
       case 'StatusList2021Credential':

--- a/packages/w3c-credential-status/src/lib/index.ts
+++ b/packages/w3c-credential-status/src/lib/index.ts
@@ -1,5 +1,4 @@
 import {
-  BBS_V1_URL,
   CredentialContextVersion,
   DATA_INTEGRITY_V2_URL,
   STATUS_LIST_2021_CREDENTIAL_URL,
@@ -22,7 +21,6 @@ import {
 import {
   assertCredentialStatusStatusListType,
   getValidFromDateFromCredentialStatusVC,
-  validateCredentialStatus,
 } from './utils';
 
 export const VCCredentialStatusTypeToVCCredentialSubjectType: Record<
@@ -51,7 +49,12 @@ export const createCredentialStatusPayload = async (
 ): Promise<RawCredentialStatusVC> => {
   try {
     const { id, credentialSubject } = options;
-    await validateCredentialStatus(options, type, cryptoSuite);
+
+    if (cryptoSuite === 'BbsBlsSignature2020') {
+      throw new Error(
+        'BbsBlsSignature2020 is no longer supported. Please use the latest cryptosuite versions instead.',
+      );
+    }
 
     switch (type) {
       case 'StatusList2021Credential':
@@ -71,13 +74,7 @@ export const createCredentialStatusPayload = async (
     // Determine version based on credential type
     const isV2 = type === 'BitstringStatusListCredential';
     const context = [isV2 ? CredentialContextVersion.v2 : CredentialContextVersion.v1];
-
-    // Add cryptosuite-specific contexts
-    if (cryptoSuite === 'BbsBlsSignature2020') {
-      context.push(BBS_V1_URL);
-    } else {
-      context.push(DATA_INTEGRITY_V2_URL);
-    }
+    context.push(DATA_INTEGRITY_V2_URL);
 
     // Add status list context only for v1.1 (v2.0 has it built-in)
     if (type === 'StatusList2021Credential') {

--- a/packages/w3c-credential-status/src/lib/utils.ts
+++ b/packages/w3c-credential-status/src/lib/utils.ts
@@ -1,15 +1,13 @@
-import { DocumentLoader, getDocumentLoader, VC_V1_URL } from '@trustvc/w3c-context';
+import { DocumentLoader, getDocumentLoader } from '@trustvc/w3c-context';
 import {
   assertAllowedStatusPurpose,
   isNonNegativeInteger,
   isNumber,
   isString,
 } from './BitstringStatusList/assertions';
-import { CredentialStatusPurpose, VCCredentialStatusType } from './BitstringStatusList/types';
+import { CredentialStatusPurpose } from './BitstringStatusList/types';
 import {
   BitstringStatusListCredentialStatus,
-  CreateVCCredentialStatusOptions,
-  CryptoSuiteName,
   GeneralCredentialStatus,
   SignedCredentialStatusVC,
   TransferableRecordsCredentialStatus,

--- a/packages/w3c-credential-status/src/lib/utils.ts
+++ b/packages/w3c-credential-status/src/lib/utils.ts
@@ -188,39 +188,3 @@ export const getValidFromDateFromCredentialStatusVC = async (url: string): Promi
     return defaultValidFrom;
   }
 };
-
-export const validateCredentialStatus = async (
-  options: CreateVCCredentialStatusOptions,
-  type: VCCredentialStatusType,
-  cryptoSuite: CryptoSuiteName,
-) => {
-  const { id } = options;
-  // Do not support bbsBlsSignature for new VCs
-  if (type === 'BitstringStatusListCredential' && cryptoSuite === 'BbsBlsSignature2020') {
-    throw new Error(
-      'BbsBlsSignature2020 is no longer supported. Please use the latest cryptosuite versions instead.',
-    );
-  }
-
-  // for StatusList2021Credential verify if vc already exists
-  if (type === 'StatusList2021Credential') {
-    if (cryptoSuite !== 'BbsBlsSignature2020' || !id) {
-      throw new Error('Please use the recommended BitstringStatusListCredential instead.');
-    }
-
-    // if vc already exists with v1.1 context and StatusList2021Credential allow BbsBlsSignature2020
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const credential = (await fetchCredentialStatusVC(id)) as any;
-      if (!credential?.['@context']?.includes(VC_V1_URL)) {
-        throw new Error(
-          'Please use the recommended BitstringStatusListCredential with modern cryptosuite.',
-        );
-      }
-    } catch {
-      throw new Error(
-        'Credential Status VC not found. For creating new VCs, please use BitstringStatusListCredential with modern cryptosuite.',
-      );
-    }
-  }
-};


### PR DESCRIPTION
## Summary
- Added test case for BB2023 for creating VC with status list.
- Validation for createCredentialStatusPayload to ensure Credential Status are created for datamodel v2.0 with newer crypto suite
- Support existing 1.1 VC that are resolvable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default credential status now uses the v2 Bitstring Status List with a modern cryptosuite.
  - Automatic validation blocks unsupported combinations and provides clearer error messages.
  - Backward compatibility retained for existing v1.1 credentials when their status list is resolvable.

- Documentation
  - README updated to emphasize v2, with migration guidance, revised terminology, and examples for both v2 and legacy flows, including cryptosuite options.

- Tests
  - Expanded coverage for v2 behavior, legacy compatibility, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->