### PR TITLE
feat: add Verifiable Presentation create/sign/verify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,190 @@
+# CLAUDE.md
+
+Guidance for working in this repo — for human developers and for Claude Code.
+
+> **Keep this file alive.** This document is only useful if it stays true. Treat it
+> as part of the code: whenever a change makes something here wrong or incomplete,
+> update it *in the same commit/PR*. See [Maintaining this file](#maintaining-this-file).
+
+## What this repo is
+
+`@trustvc/w3c` is an **nx-managed npm-workspaces monorepo** for W3C Verifiable
+Credentials / Verifiable Presentations. Packages live under `packages/*`, apps
+under `apps/*`. Each package is published independently to npm (semantic-release).
+
+| Package | Responsibility |
+| --- | --- |
+| `@trustvc/w3c-vc` | Sign / verify **credentials** and **presentations** (the crypto core). |
+| `@trustvc/w3c-issuer` | Key generation, did:key / did:web issuer material, `VerificationType`. |
+| `@trustvc/w3c-context` | JSON-LD contexts + the shared **document loader** (resolves did:web, did:key, hosted contexts). |
+| `@trustvc/w3c-credential-status` | Credential status (incl. on-chain `TransferableRecords`). |
+| `@trustvc/w3c` | Umbrella package re-exporting the above. |
+
+Consumers (e.g. `@trustvc/trustvc`) depend on the **published** packages, so treat
+every public export as an API surface — see "Publishing / testing changes" below.
+
+## Commands
+
+Node **≥ 18.17** (root engines). nx caches aggressively.
+
+```bash
+# From repo root (runs across all packages):
+npm run build          # nx run-many --target=build (tsup per package)
+npm test               # nx run-many --target=test  (vitest)
+npm run lint           # tsc --noEmit + eslint, --max-warnings=0
+npm run test:skip-cache  # bypass the nx cache when results look stale
+
+# Single package (faster loop) — cd into it, or use nx:
+cd packages/w3c-vc
+npm test                                  # vitest --run --test-timeout=15000
+npx vitest --run src/lib/presentation/index.test.ts   # one file
+npx vitest --run <file> -t "did:web"      # one test by name
+npm run lint                              # tsc --noEmit && eslint (must be 0 warnings)
+npm run build                             # clean + tsup
+```
+
+**`lint` = typecheck + eslint.** CI fails on any eslint warning (`--max-warnings=0`)
+and on any tsc error. Run it before considering a change done.
+
+Some tests hit the network (did:web resolution against `trustvc.github.io`). They
+are real integration checks, not mocks — don't stub them away.
+
+## ⚠️ The jsonld override gotcha (read this before touching JSON-LD)
+
+The repo root `package.json` pins:
+
+```json
+"overrides": { "jsonld": "^6.0.0" }
+```
+
+This forces **jsonld 6** everywhere in the monorepo, but real consumers may resolve
+**jsonld 9**, which has a **much stricter safe mode**. A document that expands fine
+here can throw *"Safe mode validation error … did not expand into an absolute IRI"*
+in a downstream repo. **Passing tests here do not prove JSON-LD correctness.**
+
+Concretely: this bit us on VPs — `validFrom` / `validUntil` are only defined in the
+type-scoped context of `VerifiableCredential`, not `VerifiablePresentation`. jsonld 6
+let it slide; jsonld 9 rejected it. The fix lives in
+[packages/w3c-vc/src/lib/presentation/index.ts](packages/w3c-vc/src/lib/presentation/index.ts)
+as `VP_EXPIRY_CONTEXT` — an inline `@context` mapping those terms to canonical
+`https://www.w3.org/2018/credentials#` IRIs with `xsd:dateTime`.
+
+**Rule:** if you add or move any term onto a VC/VP envelope, verify it expands to an
+absolute IRI under jsonld's safe mode. When in doubt, test in a repo that resolves
+jsonld 9 (see below) — not just here.
+
+## Verifiable Presentations (`src/lib/presentation`)
+
+VP support was designed around a few hard rules. Preserve them:
+
+1. **`ecdsa-rdfc-2019` is the only VP holder-proof suite.** Selective-disclosure
+   suites (`ecdsa-sd-2023`, `bbs-2023`) and the deprecated `BbsBlsSignature2020`
+   **cannot sign a VP**: `verifiableCredential` is a JSON-LD `@graph`, which is not
+   JSON-pointer-addressable, so SD canonicalization fails. The holder signs the VP
+   envelope with the **same ECDSA P-256 Multikey** used for credentials — no new key
+   type needed. (Embedded credentials keep whatever suite they were issued with;
+   a VP freely mixes suites and VC data-model versions.)
+
+2. **Never allow a VP over a credential with `TransferableRecords` status.** That
+   status is controlled on-chain; presenting it off-chain is meaningless/misleading.
+   Enforced by `assertNoTransferableRecords` in both create and sign.
+
+3. **Create and verify must agree.** If `createPresentation` rejects something
+   (expired embedded credential, revoked credential, subject/holder mismatch under
+   `checkHolderBinding`), `verifyPresentation` must reject it too. We fixed an
+   asymmetry where verify accepted expired embedded VCs that create rejected — keep
+   them symmetric when you add checks.
+
+4. **Holder binding is a string-equality check across DIDs:**
+   `signingKey.controller === holder === every credentialSubject.id`. It is
+   **method-agnostic** — `did:key` and `did:web` both work. did:web only additionally
+   requires that its DID document be web-resolvable and publish the ECDSA Multikey
+   (the shared document loader handles resolution).
+
+5. **`challenge` is never trusted from the proof at verify time** — the caller (the
+   verifier) must supply it. `challenge` → `authentication` proof (anti-replay);
+   no challenge → `assertionMethod` proof. `domain` requires a `challenge`.
+
+The public API from `@trustvc/w3c-vc`: `createPresentation`, `signPresentation`,
+`verifyPresentation`, `isRawPresentation`, `isSignedPresentation` (+ the VP types in
+`src/lib/types.ts`). Note the **trustvc layer wraps these into an opinionated
+`signW3CPresentation` / `verifyW3CPresentation`** that *enforces* fullDisclosure,
+holder binding, and a mandatory lifetime — that policy lives in the consumer, not here.
+
+## Credentials (`src/lib/w3c-vc.ts`)
+
+`signCredential` / `verifyCredential` / `deriveCredential` / `isDerived`. Selective
+disclosure = a **base** credential (full, signed with `ecdsa-sd-2023` / `bbs-2023`)
+→ `deriveCredential(base, ['/json/pointer', ...])` → a **derived** credential
+revealing only those fields. A VP should carry derived (or non-SD) credentials.
+
+Note: standalone `verifyCredential` currently only **warns** on expiry (does not
+fail). The VP flow is stricter and *fails* on expired embedded credentials. If you
+change one, consider whether the other should follow.
+
+## Adding a dependency on a `@digitalbazaar/*` (or similar) package
+
+Many crypto packages ship **no types**. Add a `declare module '...';` line to
+[packages/declaration.d.ts](packages/declaration.d.ts) or tsc will fail.
+
+## Publishing / testing changes before release
+
+Because downstream consumers resolve **jsonld 9** and their own dep tree, validate
+real changes outside this monorepo before publishing:
+
+```bash
+# 1. build + pack the changed package
+cd packages/w3c-vc && npm run build && npm pack   # → trustvc-w3c-vc-x.y.z.tgz
+# 2. install the tarball into the consumer (e.g. ../trustvc-7) and run ITS tests
+#    (that repo needs Node ≥ 20; use `nvm use 20`)
+```
+
+This pre-publish loop is what caught the jsonld-9 `validFrom` bug. Do it for any
+change that touches JSON-LD, contexts, or public exports.
+
+## Conventions
+
+- **TypeScript, no `!` non-null assertions** in tests — use an `assertDefined` helper
+  (see the existing test files). Avoid `any`; prefer `as never` at test boundaries
+  when a fixture is intentionally loosely typed.
+- **Fixtures** live in `src/lib/__fixtures__/`. The did:web and did:key key pairs in
+  `key-pairs.ts` share the same underlying key material — reuse them, don't invent
+  new keys.
+- Match the surrounding file's style; keep comments explaining *why* (the rules
+  above are subtle and easy to regress).
+- Conventional commits (commitlint + semantic-release drive versioning/changelogs).
+
+## Maintaining this file
+
+**This file is documentation-as-code. Keep it in sync with the repo in the same
+change that makes it stale — not "later".**
+
+Update `CLAUDE.md` when your change touches any of:
+
+- **A public export or its behavior** — a new/renamed/removed function, a changed
+  signature, a new package. Update the package table and the relevant section.
+- **A rule or invariant** — anything in the VP "hard rules" list, holder binding,
+  the `TransferableRecords` block, create/verify symmetry, the supported cryptosuite
+  set. If you intentionally change one, change its description here and say why.
+- **Commands, scripts, tooling, or Node/engine requirements** — keep the Commands
+  section runnable exactly as written.
+- **A gotcha you just spent time on.** If something surprised you or cost you an
+  hour (a jsonld safe-mode quirk, an nx cache stale-result, a missing `declare
+  module`, a network-dependent test), add or expand a note so the next person —
+  human or Claude — doesn't repeat it. New gotchas are the highest-value additions.
+
+Guidelines:
+
+- **Small and true beats big and stale.** Delete guidance that no longer holds
+  rather than leaving it to mislead. Wrong docs are worse than none.
+- Keep it **repo-specific and actionable** — decisions, rules, and gotchas that
+  aren't obvious from the code or git history. Don't restate what a reader can see
+  by opening the file.
+- Prefer linking to the source of truth (a file/line) over duplicating detail that
+  will drift.
+- When editing a rule, keep the *why* — these invariants are load-bearing and easy
+  to "simplify" back into a bug.
+
+**For Claude Code specifically:** at the end of a task that changed any of the above,
+check whether this file is now inaccurate and propose the edit as part of the same
+work — don't wait to be asked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,6 +3109,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/-/ecdsa-rdfc-2019-cryptosuite-1.3.0.tgz",
+      "integrity": "sha512-Rhg++GnGWHJ29QyWTFW0tRqd/uGLADIsLVEq10zEIAY7D9ScoSLtyYzwZ/zBueBTXHXrtDUEL5SfrSvcKTLFyg==",
+      "dependencies": {
+        "@digitalbazaar/ecdsa-multikey": "^1.6.0",
+        "jsonld": "^9.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@digitalbazaar/ecdsa-sd-2023-cryptosuite": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-sd-2023-cryptosuite/-/ecdsa-sd-2023-cryptosuite-3.4.1.tgz",
@@ -33008,13 +33032,13 @@
     },
     "packages/w3c": {
       "name": "@trustvc/w3c",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@trustvc/w3c-context": "^2.1.0",
-        "@trustvc/w3c-credential-status": "^2.1.0",
-        "@trustvc/w3c-issuer": "^2.1.0",
-        "@trustvc/w3c-vc": "^2.1.0"
+        "@trustvc/w3c-context": "^2.2.0",
+        "@trustvc/w3c-credential-status": "^2.2.0",
+        "@trustvc/w3c-issuer": "^2.2.0",
+        "@trustvc/w3c-vc": "^2.2.0"
       },
       "engines": {
         "node": ">=18.x"
@@ -33022,7 +33046,7 @@
     },
     "packages/w3c-context": {
       "name": "@trustvc/w3c-context",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "did-resolver": "^4.1.0",
@@ -33114,11 +33138,11 @@
     },
     "packages/w3c-credential-status": {
       "name": "@trustvc/w3c-credential-status",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@trustvc/w3c-context": "^2.1.0",
-        "@trustvc/w3c-issuer": "^2.1.0",
+        "@trustvc/w3c-context": "^2.2.0",
+        "@trustvc/w3c-issuer": "^2.2.0",
         "base64url-universal": "^2.0.0",
         "pako": "^2.1.0"
       },
@@ -33128,7 +33152,7 @@
     },
     "packages/w3c-issuer": {
       "name": "@trustvc/w3c-issuer",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
@@ -33145,17 +33169,18 @@
     },
     "packages/w3c-vc": {
       "name": "@trustvc/w3c-vc",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bbs-2023-cryptosuite": "^2.0.1",
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
         "@digitalbazaar/data-integrity": "^2.5.0",
         "@digitalbazaar/ecdsa-multikey": "^1.8.0",
+        "@digitalbazaar/ecdsa-rdfc-2019-cryptosuite": "^1.3.0",
         "@digitalbazaar/ecdsa-sd-2023-cryptosuite": "^3.4.1",
         "@mattrglobal/jsonld-signatures-bbs": "^1.2.0",
-        "@trustvc/w3c-credential-status": "^2.1.0",
-        "@trustvc/w3c-issuer": "^2.1.0",
+        "@trustvc/w3c-credential-status": "^2.2.0",
+        "@trustvc/w3c-issuer": "^2.2.0",
         "base64url-universal": "^2.0.0",
         "cbor": "^9.0.2",
         "did-resolver": "^4.1.0",

--- a/packages/declaration.d.ts
+++ b/packages/declaration.d.ts
@@ -2,6 +2,7 @@ declare module '@digitalbazaar/bls12-381-multikey';
 declare module '@digitalbazaar/bbs-2023-cryptosuite';
 declare module '@digitalbazaar/ecdsa-multikey';
 declare module '@digitalbazaar/ecdsa-sd-2023-cryptosuite';
+declare module '@digitalbazaar/ecdsa-rdfc-2019-cryptosuite';
 declare module '@digitalbazaar/data-integrity';
 declare module 'jsonld';
 declare module 'jsonld-signatures';

--- a/packages/w3c-vc/README.md
+++ b/packages/w3c-vc/README.md
@@ -542,7 +542,7 @@ console.log(result.credentialResults);  // per-credential outcomes (with credent
 > fresh nonce and track/consume it. Omit it (Route 2) for a signed-but-replayable proof.
 > `verifyPresentation` requires you to pass the `challenge` **it** issued — the value in the
 > proof is never trusted (that would allow replay).
-
+>
 > **Stateless alternative for frontends.** If you have no backend to track challenges, rely
 > on the **VP expiry** instead: a short-lived signed VP + `maxLifetimeSeconds` on verify
 > gives time-boxed replay mitigation with no server state.

--- a/packages/w3c-vc/README.md
+++ b/packages/w3c-vc/README.md
@@ -12,6 +12,7 @@ This repository provides utilities for signing, verifying, and deriving Verifiab
   - [2. Verifying a Credential](#2-verifying-a-credential)
   - [3. Deriving a Credential (Selective Disclosure)](#3-deriving-a-credential-selective-disclosure)
   - [4. Schema Validation](#4-schema-validation)
+  - [5. Verifiable Presentations](#5-verifiable-presentations)
 - [Migration from Legacy BbsBlsSignature2020](#migration-from-legacy-bbsblssignature2020)
 - [Best Practices](#best-practices)
 - [License](#license)
@@ -28,6 +29,7 @@ npm install @trustvc/w3c-vc
 - **W3C Compliance**: Support for both W3C VC Data Model v1.1 and v2.0
 - **DID Method Agnostic**: Sign and verify with `did:web` issuers (hosted DID document) or `did:key` issuers (self-certifying, no hosting). See [`@trustvc/w3c-issuer`](../w3c-issuer/README.md) for issuance.
 - **Selective Disclosure**: Derive credentials with selective field revelation
+- **Verifiable Presentations**: Create (with strict input validation + mandatory expiry), sign (optional holder binding via `ecdsa-rdfc-2019`, with or without `challenge`/`domain`, `did:key` or `did:web` holder) and verify presentations that may wrap credentials of mixed cryptosuites and versions
 - **Legacy Support**: Deprecated BbsBlsSignature2020 signature support (verification only)
 - **Schema Validation**: Checks if payload matches W3C VC schema
 - **Version Detection**: Helper functions to detect credential versions
@@ -427,6 +429,147 @@ console.log('Is v2.0 raw document:', isRawDocumentV2_0(document)); // true
 // Check if credential is derived (selective disclosure)
 const signedDocument = { ...document, proof: { /* proof object */ } };
 console.log('Is derived credential:', await isDerived(signedDocument));
+```
+
+### 5. Verifiable Presentations
+
+A **Verifiable Presentation (VP)** is an envelope that a _holder_ wraps around one or
+more Verifiable Credentials to present them to a _verifier_. It has two independent
+layers:
+
+1. **The embedded credentials** (`verifiableCredential`) — each keeps its **own** proof.
+   A single VP may freely mix cryptosuites (`ecdsa-sd-2023`, `bbs-2023`,
+   `BbsBlsSignature2020`) **and** VC data-model versions (v1.1 / v2.0). Each is verified
+   independently.
+2. **An optional holder-binding proof** over the whole envelope, with a `challenge` (and
+   optional `domain`) supplied by the verifier to prevent replay. This proves the holder
+   controls the key and made _this_ presentation for _this_ verifier.
+
+#### Which cryptosuite signs the presentation?
+
+The holder proof must sign the **entire** envelope, so it uses a **plain
+(non-selective-disclosure)** suite: **`ecdsa-rdfc-2019`**. This reuses the **same ECDSA
+(P-256) Multikey** used for `ecdsa-sd-2023` credentials — the holder's signing key is
+independent of the suites used by the credentials inside. The holder DID may be a
+**`did:key`** (self-certifying, nothing to host) or a **`did:web`** — both resolve out of
+the box.
+
+> The selective-disclosure suites (`ecdsa-sd-2023`, `bbs-2023`) **cannot** sign a
+> presentation: `verifiableCredential` is a JSON-LD `@graph` container that JSON-pointer
+> selective disclosure cannot cover, so the proof would not bind the credentials being
+> presented. The deprecated `BbsBlsSignature2020` is likewise not used. `signPresentation`
+> returns a descriptive error if you request any of them. This only affects the _outer_
+> proof — the **credentials inside** the VP may still use any suite.
+>
+> A BBS-only holder (no ECDSA key) cannot produce a modern holder proof (there is no
+> non-deprecated plain BBS suite) — either generate an ECDSA key or present an **unsigned**
+> VP (see below).
+
+| Layer | Cryptosuite |
+|-------|-------------|
+| VP holder proof (outer) | `ecdsa-rdfc-2019` (ECDSA P-256 Multikey, `did:key` or `did:web`) |
+| Embedded credentials | any (`ecdsa-sd-2023`, `bbs-2023`, `BbsBlsSignature2020`), any version |
+
+#### Transferable records cannot be presented via a VP
+
+Credentials with a **`TransferableRecords`** `credentialStatus` are controlled **on-chain**
+via their token registry — possession is proven by **token ownership**, not by a
+presentation. `createPresentation` (and `signPresentation`) therefore **throw / error** if
+any embedded credential carries a `TransferableRecords` status. Present those through their
+token ownership instead.
+
+#### Strict validation at creation + mandatory expiry
+
+`createPresentation` is **async** and validates **every** input credential before producing
+a VP. If any credential is not signed, **expired**, future-dated, **revoked**, or a
+**transferable record**, it **throws with a clear reason (and index)** and **no VP is
+produced**. The VP is also stamped with a **mandatory, configurable expiry**
+(`validFrom = now`, `validUntil = now + lifetime`; default 5 minutes).
+
+The presentation **envelope** defaults to **VC Data Model v2.0** regardless of the embedded
+credentials' versions (each credential keeps its own `@context`); pass `version: 'v1'` only
+if a verifier specifically requires a v1.1 presentation.
+
+```ts
+const presentation = await createPresentation(signedCredentials, {
+  holder: 'did:web:holder.example',
+  expiresInSeconds: 300,        // VP lifetime (default 300s); or pass an explicit validUntil
+  // version: 'v2',             // envelope version (default 'v2'); wraps v1.1 or v2.0 credentials
+  // fullDisclosure: true,      // auto-derive any base SD credential (reveals ALL fields)
+});
+// throws e.g. "credential at index 0 is not valid: Invalid signature."
+//            "credential at index 1 has expired (2024-01-01T…)."
+//            "credential at index 0 has been revoked (credentialStatus)."
+```
+
+#### Three signing routes
+
+| Route | Call | Proof | Notes |
+|-------|------|-------|-------|
+| **1. Unsigned** | `createPresentation(...)` → `verifyPresentation(vp)` | none | verifies credential authenticity only |
+| **2. Signed, no challenge** | `signPresentation(vp, key)` | `assertionMethod` | proves holder signed it; **not** anti-replay |
+| **3. Signed, with challenge** | `signPresentation(vp, key, { challenge, domain })` | `authentication` | challenge/domain enforced on verify (anti-replay) |
+
+```ts
+import { createPresentation, signPresentation, verifyPresentation } from '@trustvc/w3c-vc';
+
+// `signedCredentials` are already signed (and, for SD suites, derived) — mixed suites/versions ok.
+const vp = await createPresentation(signedCredentials, { holder: 'did:web:holder.example' });
+
+// Route 3 — signed with a verifier-issued challenge (strongest; needs a server to issue/track it)
+const challenge = 'a-random-verifier-supplied-nonce';
+const { signed, error } = await signPresentation(vp, holderEcdsaKey, {
+  challenge,
+  domain: 'verifier.example.com', // optional audience binding
+});
+if (error) throw new Error(error);
+
+const result = await verifyPresentation(signed, {
+  challenge,                      // REQUIRED for an authentication proof; never read from the proof
+  domain: 'verifier.example.com',
+  requireProof: true,             // reject an unsigned VP
+  checkHolderBinding: true,       // signer DID == holder == every credentialSubject.id
+  maxLifetimeSeconds: 300,        // reject a VP whose lifetime exceeds this (defeats a huge validUntil)
+});
+
+console.log(result.verified);          // true only if the holder proof + all credentials verify + not expired
+console.log(result.presentationResult); // outcome of the holder proof (undefined if unsigned)
+console.log(result.credentialResults);  // per-credential outcomes (with credentialIndex)
+```
+
+> **`challenge`/`domain` are optional (per the W3C Data Integrity spec).** Provide a
+> `challenge` (Route 3) for **single-use** anti-replay — this needs a **server** to issue a
+> fresh nonce and track/consume it. Omit it (Route 2) for a signed-but-replayable proof.
+> `verifyPresentation` requires you to pass the `challenge` **it** issued — the value in the
+> proof is never trusted (that would allow replay).
+
+> **Stateless alternative for frontends.** If you have no backend to track challenges, rely
+> on the **VP expiry** instead: a short-lived signed VP + `maxLifetimeSeconds` on verify
+> gives time-boxed replay mitigation with no server state.
+
+#### Unsigned presentations
+
+If you only need to bundle credentials (no cryptographic holder binding), omit the
+signing step. `verifyPresentation` still verifies every embedded credential (and the VP expiry):
+
+```ts
+const presentation = await createPresentation(signedCredentials);
+const result = await verifyPresentation(presentation);
+// result.verified reflects whether all embedded credentials verify and the VP is not expired;
+// result.presentationResult is undefined (no holder proof present).
+```
+
+> **Note:** an unsigned VP does not prove who is presenting it — anyone holding a copy of
+> the credentials could send it. Sign it (Route 2/3) when you need to prove the holder
+> controls the subject's key.
+
+#### Presentation helper functions
+
+```ts
+import { isRawPresentation, isSignedPresentation } from '@trustvc/w3c-vc';
+
+isRawPresentation(presentation); // true for a structurally valid unsigned VP
+isSignedPresentation(signed); // true for a structurally valid VP carrying a proof
 ```
 
 ## Migration from Legacy BbsBlsSignature2020

--- a/packages/w3c-vc/package.json
+++ b/packages/w3c-vc/package.json
@@ -31,10 +31,11 @@
     }
   },
   "dependencies": {
-    "@digitalbazaar/bls12-381-multikey": "^2.1.0",
     "@digitalbazaar/bbs-2023-cryptosuite": "^2.0.1",
+    "@digitalbazaar/bls12-381-multikey": "^2.1.0",
     "@digitalbazaar/data-integrity": "^2.5.0",
     "@digitalbazaar/ecdsa-multikey": "^1.8.0",
+    "@digitalbazaar/ecdsa-rdfc-2019-cryptosuite": "^1.3.0",
     "@digitalbazaar/ecdsa-sd-2023-cryptosuite": "^3.4.1",
     "@mattrglobal/jsonld-signatures-bbs": "^1.2.0",
     "@trustvc/w3c-credential-status": "^2.2.0",

--- a/packages/w3c-vc/src/index.ts
+++ b/packages/w3c-vc/src/index.ts
@@ -11,14 +11,15 @@ import {
   isSignedDocumentV2_0,
   isDerived,
 } from './lib/w3c-vc';
-import {
+import { getDocumentLoader } from '@trustvc/w3c-context';
+
+export {
   createPresentation,
-  isRawPresentation,
-  isSignedPresentation,
   signPresentation,
   verifyPresentation,
+  isRawPresentation,
+  isSignedPresentation,
 } from './lib/presentation';
-import { getDocumentLoader } from '@trustvc/w3c-context';
 
 export * from './lib/types';
 export type * from './lib/types';
@@ -42,9 +43,4 @@ export {
   isSignedDocumentV1_1,
   isSignedDocumentV2_0,
   isDerived,
-  createPresentation,
-  signPresentation,
-  verifyPresentation,
-  isRawPresentation,
-  isSignedPresentation,
 };

--- a/packages/w3c-vc/src/index.ts
+++ b/packages/w3c-vc/src/index.ts
@@ -11,6 +11,13 @@ import {
   isSignedDocumentV2_0,
   isDerived,
 } from './lib/w3c-vc';
+import {
+  createPresentation,
+  isRawPresentation,
+  isSignedPresentation,
+  signPresentation,
+  verifyPresentation,
+} from './lib/presentation';
 import { getDocumentLoader } from '@trustvc/w3c-context';
 
 export * from './lib/types';
@@ -35,4 +42,9 @@ export {
   isSignedDocumentV1_1,
   isSignedDocumentV2_0,
   isDerived,
+  createPresentation,
+  signPresentation,
+  verifyPresentation,
+  isRawPresentation,
+  isSignedPresentation,
 };

--- a/packages/w3c-vc/src/lib/presentation/index.test.ts
+++ b/packages/w3c-vc/src/lib/presentation/index.test.ts
@@ -1,0 +1,718 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  createPresentation,
+  isRawPresentation,
+  isSignedPresentation,
+  signPresentation,
+  verifyPresentation,
+} from './index';
+import { deriveCredential, signCredential } from '../w3c-vc';
+import { SignedVerifiableCredential } from '../types';
+import {
+  bbs2020KeyPair,
+  bbs2023DidKeyPair,
+  BBS_DID_KEY_ISSUER,
+  ecdsa2023DidKeyPair,
+  ecdsa2023KeyPair,
+  ECDSA_DID_KEY_ISSUER,
+} from '../__fixtures__/key-pairs';
+import { modernCredentialV1_1, modernCredentialV2_0 } from '../__fixtures__/modern-credentials';
+
+const CHALLENGE = 'test-challenge-abc123';
+const DOMAIN = 'verifier.example.com';
+
+/** Asserts a value is defined and returns it narrowed (avoids `!` assertions). */
+const assertDefined = <T>(value: T | undefined, message: string): T => {
+  if (value === undefined) throw new Error(message);
+  return value;
+};
+
+/**
+ * Signs a credential and derives it (selective disclosure) so it is a
+ * verifiable, holder-presentable credential.
+ */
+const makeDerivedCredential = async (
+  credential: object,
+  keyPair: object,
+  cryptosuite: 'ecdsa-sd-2023' | 'bbs-2023',
+): Promise<SignedVerifiableCredential> => {
+  const signed = await signCredential(credential as never, keyPair as never, cryptosuite);
+  if (signed.error) throw new Error(`sign failed: ${signed.error}`);
+  const derived = await deriveCredential(
+    assertDefined(signed.signed, 'expected signed credential'),
+    ['/credentialSubject/blNumber'],
+  );
+  if (derived.error) throw new Error(`derive failed: ${derived.error}`);
+  return assertDefined(derived.derived, 'expected derived credential');
+};
+
+/** Signs a credential (base proof) without deriving, so it retains all fields. */
+const makeSignedCredential = async (
+  credential: object,
+  keyPair: object,
+  cryptosuite: 'ecdsa-sd-2023' | 'bbs-2023',
+): Promise<SignedVerifiableCredential> => {
+  const signed = await signCredential(credential as never, keyPair as never, cryptosuite);
+  if (signed.error) throw new Error(`sign failed: ${signed.error}`);
+  return assertDefined(signed.signed, 'expected signed credential');
+};
+
+describe('Verifiable Presentation', () => {
+  let ecdsaV2Vc: SignedVerifiableCredential; // ecdsa-sd-2023, v2.0
+  let bbsV1Vc: SignedVerifiableCredential; // bbs-2023, v1.1
+
+  beforeAll(async () => {
+    ecdsaV2Vc = await makeDerivedCredential(
+      { ...modernCredentialV2_0, issuer: ECDSA_DID_KEY_ISSUER, validFrom: '2024-04-01T12:19:52Z' },
+      ecdsa2023DidKeyPair,
+      'ecdsa-sd-2023',
+    );
+    bbsV1Vc = await makeDerivedCredential(
+      {
+        ...modernCredentialV1_1,
+        issuer: BBS_DID_KEY_ISSUER,
+        issuanceDate: '2024-04-01T12:19:52Z',
+      },
+      bbs2023DidKeyPair,
+      'bbs-2023',
+    );
+  });
+
+  describe('createPresentation', () => {
+    it('wraps a single credential into a VerifiablePresentation envelope', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: bbs2020KeyPair.controller });
+      expect(vp.type).toContain('VerifiablePresentation');
+      expect(vp.verifiableCredential).toEqual([ecdsaV2Vc]);
+      expect(vp.holder).toBe(bbs2020KeyPair.controller);
+      expect(vp.proof).toBeUndefined();
+      expect(vp.validFrom).toBeDefined(); // mandatory expiry stamp
+      expect(vp.validUntil).toBeDefined();
+      expect(isRawPresentation(vp)).toBe(true);
+      expect(isSignedPresentation(vp)).toBe(false);
+    });
+
+    it('stamps a configurable expiry (validUntil = validFrom + expiresInSeconds)', async () => {
+      const now = new Date('2026-01-01T00:00:00Z');
+      const vp = await createPresentation(ecdsaV2Vc, {
+        holder: ECDSA_DID_KEY_ISSUER,
+        now,
+        expiresInSeconds: 600,
+      });
+      expect(vp.validFrom).toBe('2026-01-01T00:00:00.000Z');
+      expect(vp.validUntil).toBe('2026-01-01T00:10:00.000Z');
+    });
+
+    it('wraps multiple credentials of different suites/versions', async () => {
+      const vp = await createPresentation([ecdsaV2Vc, bbsV1Vc]);
+      expect(vp.verifiableCredential).toHaveLength(2);
+    });
+
+    it('defaults to a v2 envelope even for a v1.1 credential', async () => {
+      const vp = await createPresentation(bbsV1Vc, { holder: BBS_DID_KEY_ISSUER });
+      expect((vp['@context'] as string[])[0]).toBe('https://www.w3.org/ns/credentials/v2');
+      expect(vp.validFrom).toBeDefined();
+      expect(vp.validUntil).toBeDefined();
+      expect(vp.issuanceDate).toBeUndefined();
+    });
+
+    it('emits a v1.1 envelope when version: "v1" is requested', async () => {
+      const vp = await createPresentation(bbsV1Vc, { holder: BBS_DID_KEY_ISSUER, version: 'v1' });
+      expect((vp['@context'] as string[])[0]).toBe('https://www.w3.org/2018/credentials/v1');
+      expect(vp.issuanceDate).toBeDefined();
+      expect(vp.expirationDate).toBeDefined();
+      expect(vp.validUntil).toBeUndefined();
+    });
+
+    it('throws when no credential is provided', async () => {
+      await expect(createPresentation([] as never)).rejects.toThrow();
+    });
+
+    it('throws when a credential is unsigned', async () => {
+      const { proof: _proof, ...unsigned } = ecdsaV2Vc;
+      await expect(createPresentation(unsigned as never)).rejects.toThrow(/signed/);
+    });
+  });
+
+  describe('createPresentation — holder-binding consistency check (opt-in)', () => {
+    const withSubject = (subjectId: string) =>
+      makeDerivedCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2024-04-01T12:19:52Z',
+          credentialSubject: {
+            ...(modernCredentialV2_0.credentialSubject as object),
+            id: subjectId,
+          },
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+
+    it('passes when every credential is about the holder', async () => {
+      const vc = await withSubject(ECDSA_DID_KEY_ISSUER);
+      const vp = await createPresentation([vc], {
+        holder: ECDSA_DID_KEY_ISSUER,
+        checkHolderBinding: true,
+      });
+      expect(vp.verifiableCredential).toHaveLength(1);
+    });
+
+    it('throws when a credential is about someone else', async () => {
+      const vc = await withSubject('did:example:someone-else');
+      await expect(
+        createPresentation(vc, { holder: ECDSA_DID_KEY_ISSUER, checkHolderBinding: true }),
+      ).rejects.toThrow(/does not match the holder/);
+    });
+
+    it('throws when a credential has no credentialSubject.id', async () => {
+      // ecdsaV2Vc has no subject id
+      await expect(
+        createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER, checkHolderBinding: true }),
+      ).rejects.toThrow(/no "credentialSubject.id"/);
+    });
+  });
+
+  describe('signPresentation — checkHolderBinding (correct signing key)', () => {
+    it('signs when the key DID matches the holder', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        checkHolderBinding: true,
+      });
+      expect(error).toBeUndefined();
+      expect(signed).toBeDefined();
+    });
+
+    it('refuses to sign with a key that does not match the holder', async () => {
+      // holder claims someone else, but we sign with the ecdsa did:key
+      const vp = await createPresentation(ecdsaV2Vc, { holder: 'did:example:someone-else' });
+      const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        checkHolderBinding: true,
+      });
+      expect(signed).toBeUndefined();
+      expect(error).toMatch(/does not match the presentation holder/);
+    });
+  });
+
+  describe('signPresentation + verifyPresentation (ecdsa-rdfc-2019 holder proof)', () => {
+    it('signs a VP and verifies it, including challenge/domain', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const result = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        domain: DOMAIN,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.signed?.proof?.type).toBe('DataIntegrityProof');
+      expect(result.signed?.proof?.cryptosuite).toBe('ecdsa-rdfc-2019');
+      expect(result.signed?.proof?.challenge).toBe(CHALLENGE);
+      expect(isSignedPresentation(result.signed)).toBe(true);
+
+      const verified = await verifyPresentation(
+        assertDefined(result.signed, 'expected signed VP'),
+        {
+          challenge: CHALLENGE,
+          domain: DOMAIN,
+        },
+      );
+      expect(verified.verified).toBe(true);
+      expect(verified.presentationResult?.verified).toBe(true);
+      expect(verified.credentialResults?.every((r) => r.verified)).toBe(true);
+    });
+
+    it('verifies a VP mixing ecdsa-sd-2023 (v2) and bbs-2023 (v1) credentials', async () => {
+      const vp = await createPresentation([ecdsaV2Vc, bbsV1Vc], {
+        holder: ECDSA_DID_KEY_ISSUER,
+      });
+      const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+      });
+      expect(error).toBeUndefined();
+
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+      });
+      expect(verified.verified).toBe(true);
+      expect(verified.credentialResults).toHaveLength(2);
+      expect(verified.credentialResults?.every((r) => r.verified)).toBe(true);
+    });
+
+    it('fails verification when the challenge does not match', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: 'wrong-challenge',
+      });
+      expect(verified.verified).toBe(false);
+      expect(verified.presentationResult?.verified).toBe(false);
+    });
+
+    it('requires a caller-supplied challenge to verify a signed VP (no fallback to proof.challenge)', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+
+      // No challenge passed on verify — must fail even though proof.challenge exists.
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {});
+      expect(verified.verified).toBe(false);
+      expect(verified.presentationResult?.verified).toBe(false);
+      expect(verified.error).toMatch(/caller-supplied "challenge" is required/);
+    });
+
+    it('fails verification when the domain does not match', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        domain: DOMAIN,
+      });
+
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        domain: 'attacker.example',
+      });
+      expect(verified.verified).toBe(false);
+    });
+
+    it('fails verification when an embedded credential is tampered with', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+
+      // Tamper: mutate a disclosed claim on the embedded credential.
+      const tampered = JSON.parse(JSON.stringify(signed));
+      tampered.verifiableCredential[0].credentialSubject.blNumber = 'TAMPERED';
+
+      const verified = await verifyPresentation(tampered, { challenge: CHALLENGE });
+      expect(verified.verified).toBe(false);
+    });
+  });
+
+  describe('signPresentation rejects unsupported suites / keys', () => {
+    it('rejects ecdsa-sd-2023 for the presentation proof with an explanatory error', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const result = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        cryptoSuite: 'ecdsa-sd-2023' as never,
+      });
+      expect(result.signed).toBeUndefined();
+      expect(result.error).toMatch(/cannot sign a Verifiable Presentation/);
+    });
+
+    it('rejects bbs-2023 for the presentation proof', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const result = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        cryptoSuite: 'bbs-2023' as never,
+      });
+      expect(result.signed).toBeUndefined();
+      expect(result.error).toMatch(/cannot sign a Verifiable Presentation/);
+    });
+
+    it('rejects a BBS key (only an ECDSA key can produce the presentation proof)', async () => {
+      const vp = await createPresentation(bbsV1Vc, { holder: BBS_DID_KEY_ISSUER });
+      const result = await signPresentation(vp, bbs2023DidKeyPair, { challenge: CHALLENGE });
+      expect(result.signed).toBeUndefined();
+      expect(result.error).toMatch(/ECDSA/);
+    });
+
+    it('rejects a domain without a challenge', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const result = await signPresentation(vp, ecdsa2023DidKeyPair, { domain: 'x.example' });
+      expect(result.signed).toBeUndefined();
+      expect(result.error).toMatch(/"domain" requires a "challenge"/);
+    });
+
+    it('returns a clear error when no key is provided', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const result = await signPresentation(vp, undefined as never, { challenge: CHALLENGE });
+      expect(result.signed).toBeUndefined();
+      expect(result.error).toMatch(/signing key \(keyPair\) is required/);
+    });
+  });
+
+  describe('signing without a challenge (assertionMethod proof, no challenge/domain)', () => {
+    it('signs with no challenge/domain and verifies without a challenge', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair);
+      expect(error).toBeUndefined();
+      expect(signed?.proof?.proofPurpose).toBe('assertionMethod');
+      expect(signed?.proof?.challenge).toBeUndefined();
+      expect(signed?.proof?.domain).toBeUndefined();
+
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {});
+      expect(verified.verified).toBe(true);
+      expect(verified.presentationResult?.verified).toBe(true);
+    });
+
+    it('still supports holder binding on an assertion proof', async () => {
+      const vc = await makeDerivedCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2024-04-01T12:19:52Z',
+          credentialSubject: {
+            ...(modernCredentialV2_0.credentialSubject as object),
+            id: ECDSA_DID_KEY_ISSUER,
+          },
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+      const vp = await createPresentation(vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair); // no challenge
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        checkHolderBinding: true,
+      });
+      expect(verified.verified).toBe(true);
+    });
+  });
+
+  describe('rejects TransferableRecords credentials', () => {
+    let transferableRecordVc: SignedVerifiableCredential;
+
+    beforeAll(async () => {
+      // The modern credential fixtures carry a TransferableRecords credentialStatus;
+      // a base (non-derived) signature retains it.
+      transferableRecordVc = await makeSignedCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2024-04-01T12:19:52Z',
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+      expect(transferableRecordVc.credentialStatus).toBeDefined();
+    });
+
+    it('createPresentation throws for a TransferableRecords credential', async () => {
+      await expect(createPresentation(transferableRecordVc)).rejects.toThrow(/TransferableRecords/);
+    });
+
+    it('createPresentation throws when any credential in the list is a TransferableRecord', async () => {
+      await expect(createPresentation([ecdsaV2Vc, transferableRecordVc])).rejects.toThrow(
+        /TransferableRecords/,
+      );
+    });
+
+    it('signPresentation errors for a hand-built VP containing a TransferableRecords credential', async () => {
+      const vp = {
+        '@context': [
+          'https://www.w3.org/ns/credentials/v2',
+          'https://w3id.org/security/data-integrity/v2',
+        ],
+        type: ['VerifiablePresentation'],
+        holder: ECDSA_DID_KEY_ISSUER,
+        verifiableCredential: [transferableRecordVc],
+      };
+      const result = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+      expect(result.signed).toBeUndefined();
+      expect(result.error).toMatch(/TransferableRecords/);
+    });
+  });
+
+  describe('fullDisclosure: auto-derive non-derived credentials when signing', () => {
+    // A source credential WITHOUT TransferableRecords (so the VP rule allows it).
+    const noTrSource = () => {
+      const {
+        credentialStatus: _credentialStatus,
+        qrCode: _qrCode,
+        renderMethod: _renderMethod,
+        ...rest
+      }: Record<string, unknown> = JSON.parse(JSON.stringify(modernCredentialV2_0));
+      return {
+        ...rest,
+        issuer: ECDSA_DID_KEY_ISSUER,
+        validFrom: '2024-04-01T12:19:52Z',
+        credentialSubject: {
+          ...(rest.credentialSubject as object),
+          id: ECDSA_DID_KEY_ISSUER,
+        },
+      };
+    };
+
+    it('a base (non-derived) credential is REJECTED at creation without fullDisclosure', async () => {
+      const base = await makeSignedCredential(noTrSource(), ecdsa2023DidKeyPair, 'ecdsa-sd-2023');
+      await expect(createPresentation(base, { holder: ECDSA_DID_KEY_ISSUER })).rejects.toThrow(
+        /must be derived/,
+      );
+    });
+
+    it('fullDisclosure auto-derives the base credential so the VP is created and verifies', async () => {
+      const base = await makeSignedCredential(noTrSource(), ecdsa2023DidKeyPair, 'ecdsa-sd-2023');
+      const vp = await createPresentation(base, {
+        holder: ECDSA_DID_KEY_ISSUER,
+        fullDisclosure: true,
+      });
+
+      const embedded = vp.verifiableCredential;
+      const first = Array.isArray(embedded) ? embedded[0] : embedded;
+      // The base credential was replaced with its derived (verifiable) form, disclosing all fields.
+      expect(first?.credentialSubject).toBeDefined();
+      expect((first?.credentialSubject as Record<string, unknown>).blNumber).toBe('SGCNM21566325');
+
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+      });
+      expect(verified.verified).toBe(true);
+    });
+
+    it('leaves already-derived credentials untouched under fullDisclosure', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, {
+        holder: ECDSA_DID_KEY_ISSUER,
+        fullDisclosure: true,
+      });
+      const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+      });
+      expect(error).toBeUndefined();
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+      });
+      expect(verified.verified).toBe(true);
+    });
+  });
+
+  describe('VP expiry & strict creation-time validation', () => {
+    it('rejects an expired VP at verify time', async () => {
+      const created = new Date('2026-01-01T00:00:00Z');
+      const vp = await createPresentation(ecdsaV2Vc, {
+        holder: ECDSA_DID_KEY_ISSUER,
+        now: created,
+        expiresInSeconds: 60,
+      });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+
+      // Verify 2 minutes later — past validUntil.
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        now: new Date('2026-01-01T00:02:00Z'),
+      });
+      expect(verified.verified).toBe(false);
+      expect(verified.error).toMatch(/has expired/);
+    });
+
+    it('enforces maxLifetimeSeconds at verify time', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, {
+        holder: ECDSA_DID_KEY_ISSUER,
+        expiresInSeconds: 3600, // 1 hour
+      });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        maxLifetimeSeconds: 300, // only accept <= 5 min
+      });
+      expect(verified.verified).toBe(false);
+      expect(verified.error).toMatch(/exceeds the maximum allowed/);
+    });
+
+    it('rejects an EXPIRED input credential at creation (no VP produced)', async () => {
+      // modernCredentialV2_0 has validUntil 2029; reveal it, then treat "now" as 2030.
+      const signed = await signCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2024-04-01T12:19:52Z',
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+      const derived = await deriveCredential(assertDefined(signed.signed, 'signed'), [
+        '/credentialSubject/blNumber',
+        '/validUntil',
+      ]);
+      const expiredVc = assertDefined(derived.derived, 'derived');
+      expect(expiredVc.validUntil).toBeDefined();
+
+      await expect(
+        createPresentation(expiredVc, {
+          holder: ECDSA_DID_KEY_ISSUER,
+          now: new Date('2030-01-01T00:00:00Z'),
+        }),
+      ).rejects.toThrow(/has expired/);
+    });
+
+    it('rejects a VP at VERIFY when an embedded credential has expired (consistent with creation)', async () => {
+      // Build a VP whose embedded credential expires in 2021, created in 2020 (so creation passes).
+      const signed = await signCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2020-01-01T00:00:00Z',
+          validUntil: '2021-01-01T00:00:00Z',
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+      const expiredVc = assertDefined(
+        (await deriveCredential(assertDefined(signed.signed, 'signed'), ['/validUntil'])).derived,
+        'derived',
+      );
+      // create in 2020 (VC still valid then) with a long VP lifetime so the VP itself isn't expired.
+      const vp = await createPresentation(expiredVc, {
+        holder: ECDSA_DID_KEY_ISSUER,
+        now: new Date('2020-06-01T00:00:00Z'),
+        expiresInSeconds: 315360000, // 10 years
+      });
+      const { signed: signedVp } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+      });
+
+      // Verify "now" (2026): the embedded credential is expired → VP must fail.
+      const verified = await verifyPresentation(assertDefined(signedVp, 'signed VP'), {
+        challenge: CHALLENGE,
+      });
+      expect(verified.verified).toBe(false);
+      expect(verified.credentialResults?.[0].verified).toBe(false);
+      expect(verified.credentialResults?.[0].error).toMatch(/has expired/);
+    });
+  });
+
+  describe('unsigned presentations', () => {
+    it('verifies embedded credentials of an unsigned VP (no holder proof)', async () => {
+      const vp = await createPresentation([ecdsaV2Vc, bbsV1Vc]);
+      const verified = await verifyPresentation(vp, {});
+      expect(verified.verified).toBe(true);
+      expect(verified.presentationResult).toBeUndefined();
+      expect(verified.credentialResults).toHaveLength(2);
+    });
+
+    it('rejects an unsigned VP when requireProof is set', async () => {
+      const vp = await createPresentation([ecdsaV2Vc, bbsV1Vc]);
+      const verified = await verifyPresentation(vp, { requireProof: true });
+      expect(verified.verified).toBe(false);
+      expect(verified.error).toMatch(/holder proof is required/);
+    });
+
+    it('accepts a signed VP when requireProof is set (with challenge)', async () => {
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        requireProof: true,
+        challenge: CHALLENGE,
+      });
+      expect(verified.verified).toBe(true);
+    });
+
+    it('rejects at creation when an embedded credential is invalid (strict)', async () => {
+      const tampered = JSON.parse(JSON.stringify(ecdsaV2Vc));
+      tampered.credentialSubject.blNumber = 'TAMPERED';
+      // Strict creation: an invalid credential fails createPresentation — no VP is produced.
+      await expect(createPresentation(tampered)).rejects.toThrow(/is not valid/);
+    });
+  });
+
+  describe('holder binding (proves the presenter owns the credentials)', () => {
+    // Builds a derived credential whose credentialSubject.id is `subjectId`.
+    const credWithSubject = (subjectId: string) =>
+      makeDerivedCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2024-04-01T12:19:52Z',
+          credentialSubject: {
+            ...(modernCredentialV2_0.credentialSubject as object),
+            id: subjectId,
+          },
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+
+    // The holder key (ecdsa2023DidKeyPair) signs with this DID:
+    const SIGNER_DID = ECDSA_DID_KEY_ISSUER;
+
+    it('passes when the signer DID == holder == every credentialSubject.id', async () => {
+      const vc = await credWithSubject(SIGNER_DID);
+      const vp = await createPresentation(vc, { holder: SIGNER_DID });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        checkHolderBinding: true,
+      });
+      expect(verified.verified).toBe(true);
+    });
+
+    it('fails when the presentation is signed by someone other than the holder (ownership hole closed)', async () => {
+      // credentialSubject.id and holder both claim "alice", but the VP is signed by
+      // the ecdsa did:key (not alice). A plain string check would pass; this must fail.
+      const vc = await credWithSubject('did:example:alice');
+      const vp = await createPresentation(vc, { holder: 'did:example:alice' });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        checkHolderBinding: true,
+      });
+      expect(verified.verified).toBe(false);
+      expect(verified.error).toMatch(/signed by .* does not match the declared holder/);
+    });
+
+    it('fails when a credential is about someone other than the holder/signer', async () => {
+      const vc = await credWithSubject('did:example:not-the-holder');
+      const vp = await createPresentation(vc, { holder: SIGNER_DID });
+      const { signed } = await signPresentation(vp, ecdsa2023DidKeyPair, { challenge: CHALLENGE });
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        checkHolderBinding: true,
+      });
+      expect(verified.verified).toBe(false);
+      expect(verified.error).toMatch(/does not match the presentation holder\/signer/);
+    });
+
+    it('fails holder binding on an unsigned VP (ownership cannot be proven without a signature)', async () => {
+      const vc = await credWithSubject(SIGNER_DID);
+      const vp = await createPresentation(vc, { holder: SIGNER_DID });
+      const verified = await verifyPresentation(vp, { checkHolderBinding: true });
+      expect(verified.verified).toBe(false);
+      expect(verified.error).toMatch(/requires a signed presentation/);
+    });
+  });
+
+  // A did:web holder/subject must work exactly like a did:key one. The only extra
+  // requirement is that the did:web resolves (its DID document publishes the ECDSA
+  // Multikey). `ecdsa2023KeyPair` is controlled by did:web:trustvc.github.io:did:1,
+  // whose DID document is hosted and resolvable by the default document loader —
+  // the same did:web the credential tests already sign/verify against.
+  describe('did:web holder / credentialSubject.id', () => {
+    const WEB_DID = ecdsa2023KeyPair.controller; // did:web:trustvc.github.io:did:1
+
+    const webCredential = () =>
+      makeDerivedCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: WEB_DID,
+          validFrom: '2024-04-01T12:19:52Z',
+          credentialSubject: {
+            ...(modernCredentialV2_0.credentialSubject as object),
+            id: WEB_DID,
+          },
+        },
+        ecdsa2023KeyPair,
+        'ecdsa-sd-2023',
+      );
+
+    it('signs and verifies a VP whose holder/subject is a did:web (with holder binding)', async () => {
+      const vc = await webCredential();
+      const vp = await createPresentation(vc, { holder: WEB_DID, checkHolderBinding: true });
+      const { signed, error } = await signPresentation(vp, ecdsa2023KeyPair, {
+        challenge: CHALLENGE,
+        domain: DOMAIN,
+        checkHolderBinding: true,
+      });
+      expect(error).toBeUndefined();
+      expect(signed?.proof?.cryptosuite).toBe('ecdsa-rdfc-2019');
+      expect(signed?.proof?.verificationMethod).toContain(WEB_DID);
+
+      const verified = await verifyPresentation(assertDefined(signed, 'expected signed VP'), {
+        challenge: CHALLENGE,
+        domain: DOMAIN,
+        checkHolderBinding: true,
+      });
+      expect(verified.verified).toBe(true);
+      expect(verified.presentationResult?.verified).toBe(true);
+      expect(verified.credentialResults?.every((r) => r.verified)).toBe(true);
+    });
+  });
+});

--- a/packages/w3c-vc/src/lib/presentation/index.test.ts
+++ b/packages/w3c-vc/src/lib/presentation/index.test.ts
@@ -102,6 +102,22 @@ describe('Verifiable Presentation', () => {
       expect(vp.validUntil).toBe('2026-01-01T00:10:00.000Z');
     });
 
+    it('rejects a malformed validFrom', async () => {
+      await expect(
+        createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER, validFrom: 'not-a-date' }),
+      ).rejects.toThrow(/"validFrom" is not a valid ISO date-time/);
+    });
+
+    it('rejects a validUntil that is not after validFrom (born-expired VP)', async () => {
+      await expect(
+        createPresentation(ecdsaV2Vc, {
+          holder: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2026-01-01T00:00:00Z',
+          validUntil: '2025-01-01T00:00:00Z',
+        }),
+      ).rejects.toThrow(/must be a valid time after "validFrom"/);
+    });
+
     it('wraps multiple credentials of different suites/versions', async () => {
       const vp = await createPresentation([ecdsaV2Vc, bbsV1Vc]);
       expect(vp.verifiableCredential).toHaveLength(2);
@@ -174,8 +190,25 @@ describe('Verifiable Presentation', () => {
   });
 
   describe('signPresentation — checkHolderBinding (correct signing key)', () => {
-    it('signs when the key DID matches the holder', async () => {
-      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+    // A credential actually bound to the ECDSA did:key holder (subject id set).
+    const boundVc = () =>
+      makeDerivedCredential(
+        {
+          ...modernCredentialV2_0,
+          issuer: ECDSA_DID_KEY_ISSUER,
+          validFrom: '2024-04-01T12:19:52Z',
+          credentialSubject: {
+            ...(modernCredentialV2_0.credentialSubject as object),
+            id: ECDSA_DID_KEY_ISSUER,
+          },
+        },
+        ecdsa2023DidKeyPair,
+        'ecdsa-sd-2023',
+      );
+
+    it('signs when the key DID matches the holder and subject', async () => {
+      const vc = await boundVc();
+      const vp = await createPresentation(vc, { holder: ECDSA_DID_KEY_ISSUER });
       const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair, {
         challenge: CHALLENGE,
         checkHolderBinding: true,
@@ -193,6 +226,17 @@ describe('Verifiable Presentation', () => {
       });
       expect(signed).toBeUndefined();
       expect(error).toMatch(/does not match the presentation holder/);
+    });
+
+    it('refuses to sign (does not silently pass) when a credential has no subject id', async () => {
+      // ecdsaV2Vc has no credentialSubject.id — holder binding cannot be established.
+      const vp = await createPresentation(ecdsaV2Vc, { holder: ECDSA_DID_KEY_ISSUER });
+      const { signed, error } = await signPresentation(vp, ecdsa2023DidKeyPair, {
+        challenge: CHALLENGE,
+        checkHolderBinding: true,
+      });
+      expect(signed).toBeUndefined();
+      expect(error).toMatch(/no "credentialSubject.id"/);
     });
   });
 

--- a/packages/w3c-vc/src/lib/presentation/index.ts
+++ b/packages/w3c-vc/src/lib/presentation/index.ts
@@ -44,7 +44,7 @@ const PRESENTATION_PROOF_CRYPTOSUITE = 'ecdsa-rdfc-2019';
 // with them either throws or silently drops the credentials from the signed
 // payload, so the holder proof would not cover the credentials being presented.
 // (Embedded credentials may still use these suites.)
-const UNSUPPORTED_PROOF_SUITES = ['ecdsa-sd-2023', 'bbs-2023', 'BbsBlsSignature2020'];
+const UNSUPPORTED_PROOF_SUITES = new Set(['ecdsa-sd-2023', 'bbs-2023', 'BbsBlsSignature2020']);
 
 /**
  * Normalises the `verifiableCredential` field into an array of credentials.
@@ -492,14 +492,26 @@ export const createPresentation = async (
     }
   }
 
-  // Mandatory expiry stamp.
+  // Mandatory expiry stamp. Validate any caller-supplied bounds so a malformed date
+  // cannot throw a raw RangeError and a born-expired VP is rejected up front.
   const validFrom = options?.validFrom ?? now.toISOString();
+  if (Number.isNaN(new Date(validFrom).getTime())) {
+    throw new Error(`"validFrom" is not a valid ISO date-time: "${validFrom}".`);
+  }
   const validUntil =
     options?.validUntil ??
     new Date(
       new Date(validFrom).getTime() +
         (options?.expiresInSeconds ?? DEFAULT_VP_LIFETIME_SECONDS) * 1000,
     ).toISOString();
+  if (
+    Number.isNaN(new Date(validUntil).getTime()) ||
+    new Date(validUntil).getTime() <= new Date(validFrom).getTime()
+  ) {
+    throw new Error(
+      `"validUntil" (${validUntil}) must be a valid time after "validFrom" (${validFrom}).`,
+    );
+  }
 
   const presentation: RawVerifiablePresentation = {
     '@context': context,
@@ -572,7 +584,7 @@ export const signPresentation = async (
   try {
     const cryptoSuite = options?.cryptoSuite ?? PRESENTATION_PROOF_CRYPTOSUITE;
 
-    if (UNSUPPORTED_PROOF_SUITES.includes(cryptoSuite)) {
+    if (UNSUPPORTED_PROOF_SUITES.has(cryptoSuite)) {
       return {
         error:
           `"${cryptoSuite}" cannot sign a Verifiable Presentation. Selective-disclosure ` +
@@ -611,7 +623,15 @@ export const signPresentation = async (
     if (options?.checkHolderBinding) {
       const signerDid = keyPair.controller ?? getDidFromId(keyPair.id);
       const holder = readId(presentation.holder);
-      if (holder && signerDid && holder !== signerDid) {
+      // A missing DID must FAIL, not silently pass — otherwise the opt-in check no-ops
+      // in exactly the unbound case it exists to catch (mirrors createPresentation and
+      // verifyPresentation, which both hard-fail here).
+      if (!signerDid) {
+        return {
+          error: 'holder binding requires a signing key with a resolvable DID (controller/id).',
+        };
+      }
+      if (holder && holder !== signerDid) {
         return {
           error: `the signing key "${signerDid}" does not match the presentation holder "${holder}".`,
         };
@@ -620,7 +640,12 @@ export const signPresentation = async (
       const credentials = getCredentials(presentation);
       for (let i = 0; i < credentials.length; i++) {
         const subjectId = readId(getFirstSubject(credentials[i]));
-        if (subjectId && owner && subjectId !== owner) {
+        if (!subjectId) {
+          return {
+            error: `credential at index ${i} has no "credentialSubject.id", so it cannot be bound to the holder.`,
+          };
+        }
+        if (subjectId !== owner) {
           return {
             error:
               `credential at index ${i} is about "${subjectId}", which does not match the ` +
@@ -667,6 +692,191 @@ export const signPresentation = async (
     }
     return { error: err.message };
   }
+};
+
+type HolderProofResult = PresentationVerificationResult['presentationResult'];
+
+/**
+ * Stage 0 — temporal validity of the presentation envelope itself: reject an expired
+ * or not-yet-valid VP, and (when `maxLifetimeSeconds` is set) one whose own lifetime
+ * exceeds the cap so a far-future `validUntil` can't defeat the expiry.
+ * @returns {string | undefined} An error message, or undefined when temporally valid.
+ */
+const checkVpTemporalValidity = (
+  presentation: VerifiablePresentation,
+  vpNow: Date,
+  maxLifetimeSeconds?: number,
+): string | undefined => {
+  const { from, until } = getValidityBounds(presentation);
+  if (until && vpNow > new Date(until)) {
+    return `presentation has expired (validUntil ${until}).`;
+  }
+  if (from && vpNow < new Date(from)) {
+    return `presentation is not yet valid (validFrom ${from}).`;
+  }
+  if (maxLifetimeSeconds != null && from && until) {
+    const lifetimeSeconds = (new Date(until).getTime() - new Date(from).getTime()) / 1000;
+    if (lifetimeSeconds > maxLifetimeSeconds) {
+      return (
+        `presentation lifetime (${lifetimeSeconds}s) exceeds the maximum allowed ` +
+        `(${maxLifetimeSeconds}s).`
+      );
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Stage 1 — verify each embedded credential independently (any suite / version).
+ * Expiry and revocation are enforced here too (verifyCredential only checks the
+ * signature) so a VP is rejected for an expired or revoked embedded credential —
+ * consistent with createPresentation's strict creation.
+ */
+const verifyEmbeddedCredentials = async (
+  credentials: SignedVerifiableCredential[],
+  vpNow: Date,
+  documentLoader: DocumentLoader,
+): Promise<CredentialVerificationResult[]> => {
+  const credentialResults: CredentialVerificationResult[] = [];
+  for (let i = 0; i < credentials.length; i++) {
+    let result = await verifyCredential(credentials[i], { documentLoader });
+    if (result.verified) {
+      try {
+        assertCredentialTemporallyValid(credentials[i], i, vpNow);
+        await assertCredentialNotRevoked(credentials[i], i, documentLoader);
+      } catch (err) {
+        result = {
+          verified: false,
+          error: err instanceof Error ? err.message : 'credential is no longer valid',
+        };
+      }
+    }
+    credentialResults.push({ ...result, credentialIndex: i });
+  }
+  return credentialResults;
+};
+
+/**
+ * Stage 2 — verify the holder-binding proof, if present. Only `ecdsa-rdfc-2019`
+ * DataIntegrityProofs are supported. An `authentication` proof requires a
+ * caller-supplied challenge (the proof's own challenge is never trusted); an
+ * `assertionMethod` proof takes no challenge/domain.
+ * @returns {HolderProofResult} The proof result, or undefined when the VP is unsigned.
+ */
+const verifyHolderProof = async (
+  presentation: VerifiablePresentation,
+  options: { challenge?: string; domain?: string } | undefined,
+  documentLoader: DocumentLoader,
+): Promise<HolderProofResult> => {
+  if (!presentation.proof) {
+    return undefined;
+  }
+  const proof = jsonld.getValues(presentation, 'proof')[0];
+  const proofType = proof.type as ProofType;
+  const proofCryptosuite = proof.cryptosuite as string | undefined;
+  if (proofType !== 'DataIntegrityProof' || proofCryptosuite !== PRESENTATION_PROOF_CRYPTOSUITE) {
+    return {
+      verified: false,
+      error:
+        `Presentation proof type "${proofType}"` +
+        (proofCryptosuite ? ` (cryptosuite "${proofCryptosuite}")` : '') +
+        ` is not supported. Only "${PRESENTATION_PROOF_CRYPTOSUITE}" holder proofs are supported.`,
+    };
+  }
+
+  const runVerify = async (purpose: unknown) =>
+    jsonldSignatures.verify(presentation, {
+      suite: new DataIntegrityProof({ cryptosuite: ecdsaRdfc2019Cryptosuite.cryptosuite }),
+      purpose,
+      documentLoader,
+    });
+  const toResult = (result: { verified: boolean; error?: { errors?: { message?: string }[] } }) =>
+    result.verified
+      ? { verified: true }
+      : {
+          verified: false,
+          error: result.error?.errors?.[0]?.message ?? 'Presentation proof verification error.',
+        };
+
+  const proofPurpose = proof.proofPurpose as string | undefined;
+  if (proofPurpose === 'authentication') {
+    // The challenge MUST be supplied by the caller (the verifier), not read from the
+    // proof — trusting the proof's own challenge would defeat replay protection.
+    const challenge = options?.challenge;
+    if (!challenge) {
+      return {
+        verified: false,
+        error:
+          'A caller-supplied "challenge" is required to verify an authentication ' +
+          'presentation proof. Pass the challenge the verifier issued; the value embedded ' +
+          'in the proof is not trusted.',
+      };
+    }
+    return toResult(
+      await runVerify(new AuthenticationProofPurpose({ challenge, domain: options?.domain })),
+    );
+  }
+  if (proofPurpose === 'assertionMethod') {
+    // Assertion proof: no challenge/domain. Proves the holder's key signed the VP
+    // (integrity + control at signing time) but is NOT anti-replay.
+    return toResult(await runVerify(new AssertionProofPurpose()));
+  }
+  return {
+    verified: false,
+    error: `Presentation proof purpose "${proofPurpose}" is not supported.`,
+  };
+};
+
+/**
+ * Stage 3 — optional holder binding: cryptographically prove the presenter owns the
+ * credentials. Requires a VALID holder proof AND signerDid === holder === every
+ * credentialSubject.id. Without a proof, ownership cannot be established.
+ * @returns {string | undefined} An error message, or undefined when binding holds.
+ */
+const checkHolderBindingAtVerify = (
+  presentation: VerifiablePresentation,
+  credentials: SignedVerifiableCredential[],
+  presentationResult: HolderProofResult,
+): string | undefined => {
+  if (!presentation.proof) {
+    return (
+      'holder binding requires a signed presentation (no "proof" is present, so ownership ' +
+      'cannot be proven).'
+    );
+  }
+  if (presentationResult?.verified !== true) {
+    return 'holder binding requires a valid presentation proof, but the proof did not verify.';
+  }
+  // The DID that signed the presentation (verificationMethod without its fragment).
+  const signerDid = getDidFromId(presentation.proof.verificationMethod as string | undefined);
+  const holder = readId(presentation.holder);
+  if (!signerDid) {
+    return 'the presentation proof has no "verificationMethod" to bind to.';
+  }
+  if (holder && holder !== signerDid) {
+    return (
+      `the presentation was signed by "${signerDid}", which does not match the ` +
+      `declared holder "${holder}".`
+    );
+  }
+  // Every credential must be about the presenter (the signer / holder).
+  const owner = holder ?? signerDid;
+  for (let i = 0; i < credentials.length; i++) {
+    const subjectId = readId(getFirstSubject(credentials[i]));
+    if (!subjectId) {
+      return (
+        `credential at index ${i} has no "credentialSubject.id", so it cannot be bound ` +
+        `to the holder.`
+      );
+    }
+    if (subjectId !== owner) {
+      return (
+        `credentialSubject.id ("${subjectId}") of credential at index ${i} does not ` +
+        `match the presentation holder/signer ("${owner}").`
+      );
+    }
+  }
+  return undefined;
 };
 
 /**
@@ -717,158 +927,18 @@ export const verifyPresentation = async (
     const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
 
     const vpNow = options?.now ?? new Date();
-
-    // 0. Temporal validity of the presentation itself (expiry + optional max lifetime).
-    let expiryError: string | undefined;
-    {
-      const { from, until } = getValidityBounds(presentation);
-      if (until && vpNow > new Date(until)) {
-        expiryError = `presentation has expired (validUntil ${until}).`;
-      } else if (from && vpNow < new Date(from)) {
-        expiryError = `presentation is not yet valid (validFrom ${from}).`;
-      } else if (options?.maxLifetimeSeconds != null && from && until) {
-        const lifetimeSeconds = (new Date(until).getTime() - new Date(from).getTime()) / 1000;
-        if (lifetimeSeconds > options.maxLifetimeSeconds) {
-          expiryError =
-            `presentation lifetime (${lifetimeSeconds}s) exceeds the maximum allowed ` +
-            `(${options.maxLifetimeSeconds}s).`;
-        }
-      }
-    }
-
-    // 1. Verify each embedded credential independently (any suite / version). Expiry is
-    //    enforced here too (verifyCredential only warns) so that a VP is rejected for an
-    //    expired embedded credential — consistent with createPresentation's strict creation.
     const credentials = getCredentials(presentation);
-    const credentialResults: CredentialVerificationResult[] = [];
-    for (let i = 0; i < credentials.length; i++) {
-      let result = await verifyCredential(credentials[i], { documentLoader });
-      if (result.verified) {
-        try {
-          assertCredentialTemporallyValid(credentials[i], i, vpNow);
-        } catch (err) {
-          result = { verified: false, error: err instanceof Error ? err.message : 'expired' };
-        }
-      }
-      credentialResults.push({ ...result, credentialIndex: i });
-    }
+
+    // The four verification stages (each extracted into a focused helper).
+    const expiryError = checkVpTemporalValidity(presentation, vpNow, options?.maxLifetimeSeconds);
+    const credentialResults = await verifyEmbeddedCredentials(credentials, vpNow, documentLoader);
+    const presentationResult = await verifyHolderProof(presentation, options, documentLoader);
+    const holderBindingError = options?.checkHolderBinding
+      ? checkHolderBindingAtVerify(presentation, credentials, presentationResult)
+      : undefined;
+
     const allCredentialsVerified =
       credentials.length > 0 && credentialResults.every((r) => r.verified);
-
-    // 2. Verify the holder-binding proof, if present.
-    let presentationResult: PresentationVerificationResult['presentationResult'];
-    if (presentation.proof) {
-      const proof = jsonld.getValues(presentation, 'proof')[0];
-      const proofType = proof.type as ProofType;
-      const proofCryptosuite = proof.cryptosuite as string | undefined;
-      if (
-        proofType !== 'DataIntegrityProof' ||
-        proofCryptosuite !== PRESENTATION_PROOF_CRYPTOSUITE
-      ) {
-        presentationResult = {
-          verified: false,
-          error:
-            `Presentation proof type "${proofType}"` +
-            (proofCryptosuite ? ` (cryptosuite "${proofCryptosuite}")` : '') +
-            ` is not supported. Only "${PRESENTATION_PROOF_CRYPTOSUITE}" holder proofs are supported.`,
-        };
-      } else {
-        const proofPurpose = proof.proofPurpose as string | undefined;
-        const runVerify = async (purpose: unknown) =>
-          jsonldSignatures.verify(presentation, {
-            suite: new DataIntegrityProof({ cryptosuite: ecdsaRdfc2019Cryptosuite.cryptosuite }),
-            purpose,
-            documentLoader,
-          });
-        const toResult = (result: {
-          verified: boolean;
-          error?: { errors?: { message?: string }[] };
-        }) =>
-          result.verified
-            ? { verified: true }
-            : {
-                verified: false,
-                error:
-                  result.error?.errors?.[0]?.message ?? 'Presentation proof verification error.',
-              };
-
-        if (proofPurpose === 'authentication') {
-          // The challenge MUST be supplied by the caller (the verifier), not read from
-          // the proof — trusting the proof's own challenge would defeat replay protection.
-          const challenge = options?.challenge;
-          const domain = options?.domain;
-          if (!challenge) {
-            presentationResult = {
-              verified: false,
-              error:
-                'A caller-supplied "challenge" is required to verify an authentication ' +
-                'presentation proof. Pass the challenge the verifier issued; the value embedded ' +
-                'in the proof is not trusted.',
-            };
-          } else {
-            presentationResult = toResult(
-              await runVerify(new AuthenticationProofPurpose({ challenge, domain })),
-            );
-          }
-        } else if (proofPurpose === 'assertionMethod') {
-          // Assertion proof: no challenge/domain. Proves the holder's key signed the VP
-          // (integrity + control at signing time) but is NOT anti-replay.
-          presentationResult = toResult(await runVerify(new AssertionProofPurpose()));
-        } else {
-          presentationResult = {
-            verified: false,
-            error: `Presentation proof purpose "${proofPurpose}" is not supported.`,
-          };
-        }
-      }
-    }
-
-    // 3. Optional holder binding: cryptographically prove the presenter owns the
-    //    credentials. This requires that the VP is signed AND that the signing key's
-    //    DID equals the holder equals every credentialSubject.id. Without a proof,
-    //    ownership cannot be established, so the check fails.
-    let holderBindingError: string | undefined;
-    if (options?.checkHolderBinding) {
-      if (!presentation.proof) {
-        holderBindingError =
-          'holder binding requires a signed presentation (no "proof" is present, so ownership ' +
-          'cannot be proven).';
-      } else if (presentationResult?.verified !== true) {
-        holderBindingError =
-          'holder binding requires a valid presentation proof, but the proof did not verify.';
-      } else {
-        // The DID that signed the presentation (verificationMethod without its fragment).
-        const signerDid = getDidFromId(presentation.proof.verificationMethod as string | undefined);
-        const holder = readId(presentation.holder);
-
-        if (!signerDid) {
-          holderBindingError = 'the presentation proof has no "verificationMethod" to bind to.';
-        } else if (holder && holder !== signerDid) {
-          // The presenter's signing key must belong to the declared holder.
-          holderBindingError =
-            `the presentation was signed by "${signerDid}", which does not match the ` +
-            `declared holder "${holder}".`;
-        } else {
-          // Every credential must be about the presenter (the signer / holder).
-          const owner = holder ?? signerDid;
-          for (let i = 0; i < credentials.length; i++) {
-            const subjectId = readId(getFirstSubject(credentials[i]));
-            if (!subjectId) {
-              holderBindingError =
-                `credential at index ${i} has no "credentialSubject.id", so it cannot be bound ` +
-                `to the holder.`;
-              break;
-            }
-            if (subjectId !== owner) {
-              holderBindingError =
-                `credentialSubject.id ("${subjectId}") of credential at index ${i} does not ` +
-                `match the presentation holder/signer ("${owner}").`;
-              break;
-            }
-          }
-        }
-      }
-    }
 
     // A verifier that needs holder binding can require a proof to be present.
     const missingRequiredProof = options?.requireProof && !presentation.proof;
@@ -889,16 +959,21 @@ export const verifyPresentation = async (
       aggregate.presentationResult = presentationResult;
     }
     if (!verified) {
+      // First applicable message wins, in priority order (avoids nested ternaries).
+      const requiredProofError = missingRequiredProof
+        ? 'a holder proof is required ("requireProof"), but the presentation is not signed.'
+        : undefined;
+      const noCredentialsError =
+        credentials.length === 0 ? 'presentation contains no verifiable credentials.' : undefined;
       aggregate.error =
-        expiryError ??
-        (missingRequiredProof
-          ? 'a holder proof is required ("requireProof"), but the presentation is not signed.'
-          : (holderBindingError ??
-            presentationResult?.error ??
-            credentialResults.find((r) => !r.verified)?.error ??
-            (credentials.length === 0
-              ? 'presentation contains no verifiable credentials.'
-              : 'presentation verification failed.')));
+        [
+          expiryError,
+          requiredProofError,
+          holderBindingError,
+          presentationResult?.error,
+          credentialResults.find((r) => !r.verified)?.error,
+          noCredentialsError,
+        ].find((message) => message !== undefined) ?? 'presentation verification failed.';
     }
     return aggregate;
   } catch (err: unknown) {

--- a/packages/w3c-vc/src/lib/presentation/index.ts
+++ b/packages/w3c-vc/src/lib/presentation/index.ts
@@ -128,7 +128,7 @@ const assertNoTransferableRecords = (credentials: SignedVerifiableCredential[]):
 
 // Selective-disclosure cryptosuites whose base credentials must be derived
 // before they can be verified / presented.
-const SD_CREDENTIAL_CRYPTOSUITES = ['ecdsa-sd-2023', 'bbs-2023'];
+const SD_CREDENTIAL_CRYPTOSUITES = new Set(['ecdsa-sd-2023', 'bbs-2023']);
 
 /**
  * Determines whether a credential is a base (non-derived) selective-disclosure
@@ -139,7 +139,7 @@ const SD_CREDENTIAL_CRYPTOSUITES = ['ecdsa-sd-2023', 'bbs-2023'];
  */
 const isBaseSdCredential = async (credential: SignedVerifiableCredential): Promise<boolean> => {
   const cryptosuite = credential?.proof?.cryptosuite as string | undefined;
-  if (!cryptosuite || !SD_CREDENTIAL_CRYPTOSUITES.includes(cryptosuite)) {
+  if (!cryptosuite || !SD_CREDENTIAL_CRYPTOSUITES.has(cryptosuite)) {
     return false;
   }
   return !(await isDerived(credential));

--- a/packages/w3c-vc/src/lib/presentation/index.ts
+++ b/packages/w3c-vc/src/lib/presentation/index.ts
@@ -253,20 +253,8 @@ const assertCredentialNotRevoked = async (
   }
 };
 
-/**
- * Validates the basic structure of a Verifiable Presentation.
- * @param {VerifiablePresentation} presentation - The presentation to validate.
- * @param {'sign' | 'verify'} mode - Whether the presentation is being signed or verified.
- * @throws {Error} If the presentation is structurally invalid.
- */
-const _checkPresentation = (
-  presentation: VerifiablePresentation,
-  mode: 'sign' | 'verify' = 'verify',
-): void => {
-  if (!presentation || typeof presentation !== 'object') {
-    throw new Error('"presentation" must be an object.');
-  }
-
+/** Validates the presentation `@context` (present, and a supported VC data-model URL first). */
+const checkVpContext = (presentation: VerifiablePresentation): void => {
   const contexts = jsonld.getValues(presentation, '@context');
   if (contexts.length < 1) {
     throw new Error('"@context" property is required.');
@@ -277,30 +265,42 @@ const _checkPresentation = (
       `The first element of '@context' must be either '${VC_V1_URL}' (v1.1) or '${VC_V2_URL}' (v2.0).`,
     );
   }
+};
 
+/** Validates the presentation `type` (present and includes `VerifiablePresentation`). */
+const checkVpType = (presentation: VerifiablePresentation): void => {
   if (!presentation.type) {
     throw new Error('"type" property is required.');
   }
   if (!jsonld.getValues(presentation, 'type').includes('VerifiablePresentation')) {
     throw new Error('"type" must include `VerifiablePresentation`.');
   }
+};
 
-  // `verifiableCredential`, when present, must be a credential object or an array of them.
-  if ('verifiableCredential' in presentation) {
-    const credentials = getCredentials(presentation);
-    if (credentials.length === 0) {
-      throw new Error('"verifiableCredential" must contain at least one credential.');
+/** Validates the embedded `verifiableCredential` entries (objects; signed when verifying). */
+const checkVpCredentials = (
+  presentation: VerifiablePresentation,
+  mode: 'sign' | 'verify',
+): void => {
+  if (!('verifiableCredential' in presentation)) {
+    return;
+  }
+  const credentials = getCredentials(presentation);
+  if (credentials.length === 0) {
+    throw new Error('"verifiableCredential" must contain at least one credential.');
+  }
+  for (const credential of credentials) {
+    if (!credential || typeof credential !== 'object') {
+      throw new Error('each "verifiableCredential" entry must be a credential object.');
     }
-    for (const credential of credentials) {
-      if (!credential || typeof credential !== 'object') {
-        throw new Error('each "verifiableCredential" entry must be a credential object.');
-      }
-      if (mode === 'verify' && !credential.proof) {
-        throw new Error('each "verifiableCredential" entry must be signed (missing "proof").');
-      }
+    if (mode === 'verify' && !credential.proof) {
+      throw new Error('each "verifiableCredential" entry must be signed (missing "proof").');
     }
   }
+};
 
+/** Validates the presentation `proof` (absent when signing; at most one when verifying). */
+const checkVpProof = (presentation: VerifiablePresentation, mode: 'sign' | 'verify'): void => {
   if (mode === 'sign' && presentation.proof) {
     throw new Error('"proof" property is already there.');
   }
@@ -314,11 +314,30 @@ const _checkPresentation = (
 };
 
 /**
+ * Validates the basic structure of a Verifiable Presentation.
+ * @param {VerifiablePresentation} presentation - The presentation to validate.
+ * @param {'sign' | 'verify'} mode - Whether the presentation is being signed or verified.
+ * @throws {Error} If the presentation is structurally invalid.
+ */
+const _checkPresentation = (
+  presentation: VerifiablePresentation,
+  mode: 'sign' | 'verify' = 'verify',
+): void => {
+  if (!presentation || typeof presentation !== 'object') {
+    throw new Error('"presentation" must be an object.');
+  }
+  checkVpContext(presentation);
+  checkVpType(presentation);
+  checkVpCredentials(presentation, mode);
+  checkVpProof(presentation, mode);
+};
+
+/**
  * Checks if the input document is a raw (unsigned) Verifiable Presentation.
- * @param {RawVerifiablePresentation | unknown} presentation - The presentation to check.
+ * @param {unknown} presentation - The presentation to check.
  * @returns {boolean} True if it is a structurally valid unsigned presentation.
  */
-export const isRawPresentation = (presentation: RawVerifiablePresentation | unknown): boolean => {
+export const isRawPresentation = (presentation: unknown): boolean => {
   try {
     _checkPresentation(presentation as VerifiablePresentation, 'sign');
   } catch {
@@ -329,11 +348,11 @@ export const isRawPresentation = (presentation: RawVerifiablePresentation | unkn
 
 /**
  * Checks if the input document is a signed Verifiable Presentation.
- * @param {SignedVerifiablePresentation | unknown} presentation - The presentation to check.
+ * @param {unknown} presentation - The presentation to check.
  * @returns {boolean} True if it is a structurally valid presentation carrying a proof.
  */
 export const isSignedPresentation = (
-  presentation: SignedVerifiablePresentation | unknown,
+  presentation: unknown,
 ): presentation is SignedVerifiablePresentation => {
   try {
     _checkPresentation(presentation as VerifiablePresentation, 'verify');
@@ -341,6 +360,105 @@ export const isSignedPresentation = (
     return false;
   }
   return typeof presentation === 'object' && 'proof' in (presentation as object);
+};
+
+/** Every input must be a signed credential object (carrying a "proof"). */
+const assertSignedCredentialObjects = (credentials: SignedVerifiableCredential[]): void => {
+  if (credentials.length === 0) {
+    throw new Error('"verifiableCredential" must contain at least one credential.');
+  }
+  for (const credential of credentials) {
+    if (!credential || typeof credential !== 'object' || !credential.proof) {
+      throw new Error('each credential must be a signed credential object (with a "proof").');
+    }
+  }
+};
+
+/** Strict per-credential validation: genuine signature, temporally valid, and unrevoked. */
+const assertCredentialsValidForPresentation = async (
+  credentials: SignedVerifiableCredential[],
+  now: Date,
+  documentLoader: DocumentLoader,
+): Promise<void> => {
+  for (let i = 0; i < credentials.length; i++) {
+    const verification = await verifyCredential(credentials[i], { documentLoader });
+    if (!verification.verified) {
+      throw new Error(`credential at index ${i} is not valid: ${verification.error}`);
+    }
+    assertCredentialTemporallyValid(credentials[i], i, now);
+    await assertCredentialNotRevoked(credentials[i], i, documentLoader);
+  }
+};
+
+/**
+ * Data-level holder-binding consistency: a holder must exist and every credential
+ * must be about that holder (checks credentialSubject.id, not cryptographic proof).
+ */
+const assertHolderConsistency = (
+  credentials: SignedVerifiableCredential[],
+  holder: string | undefined,
+): void => {
+  if (!holder) {
+    throw new Error(
+      'holder binding requested but no "holder" is set and no credentialSubject.id to derive it from.',
+    );
+  }
+  for (let i = 0; i < credentials.length; i++) {
+    const subjectId = readId(getFirstSubject(credentials[i]));
+    if (!subjectId) {
+      throw new Error(
+        `credential at index ${i} has no "credentialSubject.id", so it cannot be bound to the holder.`,
+      );
+    }
+    if (subjectId !== holder) {
+      throw new Error(
+        `credential at index ${i} is about "${subjectId}", which does not match the holder "${holder}".`,
+      );
+    }
+  }
+};
+
+/**
+ * Resolves and validates the mandatory VP expiry bounds. Rejects a malformed ISO
+ * `validFrom` and a `validUntil` that is not strictly after `validFrom`.
+ */
+const resolveVpValidity = (
+  options: { validFrom?: string; validUntil?: string; expiresInSeconds?: number } | undefined,
+  now: Date,
+): { validFrom: string; validUntil: string } => {
+  const validFrom = options?.validFrom ?? now.toISOString();
+  if (Number.isNaN(new Date(validFrom).getTime())) {
+    throw new TypeError(`"validFrom" is not a valid ISO date-time: "${validFrom}".`);
+  }
+  const validUntil =
+    options?.validUntil ??
+    new Date(
+      new Date(validFrom).getTime() +
+        (options?.expiresInSeconds ?? DEFAULT_VP_LIFETIME_SECONDS) * 1000,
+    ).toISOString();
+  if (
+    Number.isNaN(new Date(validUntil).getTime()) ||
+    new Date(validUntil).getTime() <= new Date(validFrom).getTime()
+  ) {
+    throw new Error(
+      `"validUntil" (${validUntil}) must be a valid time after "validFrom" (${validFrom}).`,
+    );
+  }
+  return { validFrom, validUntil };
+};
+
+/** Coerces an optional string-or-array option into an array (empty when absent). */
+const toArray = (value: string | string[] | undefined): string[] => {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+/** Builds the presentation `type` array (always leads with `VerifiablePresentation`). */
+const buildEnvelopeType = (optionType: string | string[] | undefined): string[] => {
+  const extra = toArray(optionType).filter((t) => t !== 'VerifiablePresentation');
+  return ['VerifiablePresentation', ...extra];
 };
 
 /**
@@ -401,15 +519,7 @@ export const createPresentation = async (
   let credentials = Array.isArray(verifiableCredential)
     ? verifiableCredential
     : [verifiableCredential];
-
-  if (credentials.length === 0) {
-    throw new Error('"verifiableCredential" must contain at least one credential.');
-  }
-  for (const credential of credentials) {
-    if (!credential || typeof credential !== 'object' || !credential.proof) {
-      throw new Error('each credential must be a signed credential object (with a "proof").');
-    }
-  }
+  assertSignedCredentialObjects(credentials);
 
   const now = options?.now ?? new Date();
   const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
@@ -429,16 +539,8 @@ export const createPresentation = async (
 
   // Transferable records are controlled on-chain and must not be presented via a VP.
   assertNoTransferableRecords(credentials);
-
   // Strict validation: every credential must be genuine, temporally valid, and unrevoked.
-  for (let i = 0; i < credentials.length; i++) {
-    const verification = await verifyCredential(credentials[i], { documentLoader });
-    if (!verification.verified) {
-      throw new Error(`credential at index ${i} is not valid: ${verification.error}`);
-    }
-    assertCredentialTemporallyValid(credentials[i], i, now);
-    await assertCredentialNotRevoked(credentials[i], i, documentLoader);
-  }
+  await assertCredentialsValidForPresentation(credentials, now, documentLoader);
 
   // The presentation ENVELOPE defaults to VC Data Model v2.0, independent of the embedded
   // credentials' versions (each credential keeps its own @context). Override with `version`.
@@ -452,16 +554,7 @@ export const createPresentation = async (
     ...(Array.isArray(baseContext) ? baseContext : [baseContext]),
     VP_EXPIRY_CONTEXT,
   ];
-
-  const extraTypes = options?.type
-    ? Array.isArray(options.type)
-      ? options.type
-      : [options.type]
-    : [];
-  const type = [
-    'VerifiablePresentation',
-    ...extraTypes.filter((t) => t !== 'VerifiablePresentation'),
-  ];
+  const type = buildEnvelopeType(options?.type);
 
   // Default the holder to the subject of the first credential, when present.
   const holder = options?.holder ?? readId(getFirstSubject(credentials[0]));
@@ -471,47 +564,11 @@ export const createPresentation = async (
   // holder's, or mixing credentials from different subjects. The cryptographic proof
   // (signer DID == holder == subject) is enforced later by verifyPresentation.
   if (options?.checkHolderBinding) {
-    if (!holder) {
-      throw new Error(
-        'holder binding requested but no "holder" is set and no credentialSubject.id to derive it from.',
-      );
-    }
-    for (let i = 0; i < credentials.length; i++) {
-      const subjectId = readId(getFirstSubject(credentials[i]));
-      if (!subjectId) {
-        throw new Error(
-          `credential at index ${i} has no "credentialSubject.id", so it cannot be bound to the holder.`,
-        );
-      }
-      if (subjectId !== holder) {
-        throw new Error(
-          `credential at index ${i} is about "${subjectId}", which does not match the holder ` +
-            `"${holder}".`,
-        );
-      }
-    }
+    assertHolderConsistency(credentials, holder);
   }
 
-  // Mandatory expiry stamp. Validate any caller-supplied bounds so a malformed date
-  // cannot throw a raw RangeError and a born-expired VP is rejected up front.
-  const validFrom = options?.validFrom ?? now.toISOString();
-  if (Number.isNaN(new Date(validFrom).getTime())) {
-    throw new Error(`"validFrom" is not a valid ISO date-time: "${validFrom}".`);
-  }
-  const validUntil =
-    options?.validUntil ??
-    new Date(
-      new Date(validFrom).getTime() +
-        (options?.expiresInSeconds ?? DEFAULT_VP_LIFETIME_SECONDS) * 1000,
-    ).toISOString();
-  if (
-    Number.isNaN(new Date(validUntil).getTime()) ||
-    new Date(validUntil).getTime() <= new Date(validFrom).getTime()
-  ) {
-    throw new Error(
-      `"validUntil" (${validUntil}) must be a valid time after "validFrom" (${validFrom}).`,
-    );
-  }
+  // Mandatory expiry stamp (validated: malformed / born-expired bounds are rejected).
+  const { validFrom, validUntil } = resolveVpValidity(options, now);
 
   const presentation: RawVerifiablePresentation = {
     '@context': context,
@@ -533,6 +590,56 @@ export const createPresentation = async (
     presentation.expirationDate = validUntil;
   }
   return presentation;
+};
+
+/** Returns an error message if the chosen presentation proof suite is not supported. */
+const checkPresentationSuiteError = (cryptoSuite: string): string | undefined => {
+  if (UNSUPPORTED_PROOF_SUITES.has(cryptoSuite)) {
+    return (
+      `"${cryptoSuite}" cannot sign a Verifiable Presentation. Selective-disclosure ` +
+      `suites cannot cover the "verifiableCredential" @graph, and BbsBlsSignature2020 is ` +
+      `deprecated. Use "${PRESENTATION_PROOF_CRYPTOSUITE}"; embedded credentials may still ` +
+      `use any suite.`
+    );
+  }
+  if (cryptoSuite !== PRESENTATION_PROOF_CRYPTOSUITE) {
+    return `"${cryptoSuite}" is not supported for signing a presentation.`;
+  }
+  return undefined;
+};
+
+/**
+ * Sign-time holder binding: the signing key's DID must equal the holder and every
+ * credentialSubject.id. A missing DID or subject id FAILS (never silently passes).
+ * @returns {string | undefined} An error message, or undefined when binding holds.
+ */
+const checkSignerHolderBinding = (
+  presentation: RawVerifiablePresentation,
+  keyPair: PrivateKeyPair,
+): string | undefined => {
+  const signerDid = keyPair.controller ?? getDidFromId(keyPair.id);
+  const holder = readId(presentation.holder);
+  if (!signerDid) {
+    return 'holder binding requires a signing key with a resolvable DID (controller/id).';
+  }
+  if (holder && holder !== signerDid) {
+    return `the signing key "${signerDid}" does not match the presentation holder "${holder}".`;
+  }
+  const owner = holder ?? signerDid;
+  const credentials = getCredentials(presentation);
+  for (let i = 0; i < credentials.length; i++) {
+    const subjectId = readId(getFirstSubject(credentials[i]));
+    if (!subjectId) {
+      return `credential at index ${i} has no "credentialSubject.id", so it cannot be bound to the holder.`;
+    }
+    if (subjectId !== owner) {
+      return (
+        `credential at index ${i} is about "${subjectId}", which does not match the ` +
+        `signing key / holder "${owner}".`
+      );
+    }
+  }
+  return undefined;
 };
 
 /**
@@ -583,18 +690,9 @@ export const signPresentation = async (
 ): Promise<PresentationSigningResult> => {
   try {
     const cryptoSuite = options?.cryptoSuite ?? PRESENTATION_PROOF_CRYPTOSUITE;
-
-    if (UNSUPPORTED_PROOF_SUITES.has(cryptoSuite)) {
-      return {
-        error:
-          `"${cryptoSuite}" cannot sign a Verifiable Presentation. Selective-disclosure ` +
-          `suites cannot cover the "verifiableCredential" @graph, and BbsBlsSignature2020 is ` +
-          `deprecated. Use "${PRESENTATION_PROOF_CRYPTOSUITE}"; embedded credentials may still ` +
-          `use any suite.`,
-      };
-    }
-    if (cryptoSuite !== PRESENTATION_PROOF_CRYPTOSUITE) {
-      return { error: `"${cryptoSuite}" is not supported for signing a presentation.` };
+    const suiteError = checkPresentationSuiteError(cryptoSuite);
+    if (suiteError) {
+      return { error: suiteError };
     }
 
     // A `challenge` yields an authentication proof; omitting it yields an assertion
@@ -620,38 +718,12 @@ export const signPresentation = async (
     // Optionally refuse to sign with the wrong key: the signing key's DID must match the
     // holder and every credentialSubject.id. Caught here at sign time (a verifier with
     // checkHolderBinding would otherwise catch it later).
+    // A missing DID or subject id FAILS (never silently passes) — mirrors
+    // createPresentation and verifyPresentation, which both hard-fail here.
     if (options?.checkHolderBinding) {
-      const signerDid = keyPair.controller ?? getDidFromId(keyPair.id);
-      const holder = readId(presentation.holder);
-      // A missing DID must FAIL, not silently pass — otherwise the opt-in check no-ops
-      // in exactly the unbound case it exists to catch (mirrors createPresentation and
-      // verifyPresentation, which both hard-fail here).
-      if (!signerDid) {
-        return {
-          error: 'holder binding requires a signing key with a resolvable DID (controller/id).',
-        };
-      }
-      if (holder && holder !== signerDid) {
-        return {
-          error: `the signing key "${signerDid}" does not match the presentation holder "${holder}".`,
-        };
-      }
-      const owner = holder ?? signerDid;
-      const credentials = getCredentials(presentation);
-      for (let i = 0; i < credentials.length; i++) {
-        const subjectId = readId(getFirstSubject(credentials[i]));
-        if (!subjectId) {
-          return {
-            error: `credential at index ${i} has no "credentialSubject.id", so it cannot be bound to the holder.`,
-          };
-        }
-        if (subjectId !== owner) {
-          return {
-            error:
-              `credential at index ${i} is about "${subjectId}", which does not match the ` +
-              `signing key / holder "${owner}".`,
-          };
-        }
+      const bindingError = checkSignerHolderBinding(presentation, keyPair);
+      if (bindingError) {
+        return { error: bindingError };
       }
     }
 

--- a/packages/w3c-vc/src/lib/presentation/index.ts
+++ b/packages/w3c-vc/src/lib/presentation/index.ts
@@ -1,0 +1,910 @@
+import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
+import * as ecdsaRdfc2019Cryptosuite from '@digitalbazaar/ecdsa-rdfc-2019-cryptosuite';
+import { DataIntegrityProof } from '@digitalbazaar/data-integrity';
+import {
+  DATA_INTEGRITY_V2_URL,
+  DocumentLoader,
+  getDocumentLoader,
+  VC_V1_URL,
+  VC_V2_URL,
+} from '@trustvc/w3c-context';
+import { EcdsaSd2023PrivateKeyPair, PrivateKeyPair } from '@trustvc/w3c-issuer';
+import { _checkKeyPair } from '../helper';
+import * as jsonld from 'jsonld';
+// jsonld-signatures@11 – the version compatible with the @digitalbazaar
+// DataIntegrityProof suites (same as the modern VC sign/verify path).
+import jsonldSignatures from 'jsonld-signatures';
+import {
+  CredentialVerificationResult,
+  PresentationSigningResult,
+  PresentationVerificationResult,
+  PresentationProofSuite,
+  ProofType,
+  RawVerifiablePresentation,
+  SignedVerifiableCredential,
+  SignedVerifiablePresentation,
+  VerifiablePresentation,
+} from '../types';
+import { deriveCredential, isDerived, verifyCredential } from '../w3c-vc';
+import { verifyCredentialStatus } from '../verify/credentialStatus';
+
+const {
+  purposes: { AuthenticationProofPurpose, AssertionProofPurpose },
+} = jsonldSignatures;
+
+// The cryptosuite used for a presentation's holder-binding proof. Only the plain
+// (non-selective-disclosure) `ecdsa-rdfc-2019` suite is supported — it signs the
+// whole envelope and reuses the same ECDSA Multikey used for `ecdsa-sd-2023`
+// credentials.
+const PRESENTATION_PROOF_CRYPTOSUITE = 'ecdsa-rdfc-2019';
+
+// Selective-disclosure cryptosuites cannot sign a presentation: the
+// `verifiableCredential` term is a JSON-LD `@graph` container, which the
+// JSON-pointer-based selective disclosure primitives cannot address. Signing
+// with them either throws or silently drops the credentials from the signed
+// payload, so the holder proof would not cover the credentials being presented.
+// (Embedded credentials may still use these suites.)
+const UNSUPPORTED_PROOF_SUITES = ['ecdsa-sd-2023', 'bbs-2023', 'BbsBlsSignature2020'];
+
+/**
+ * Normalises the `verifiableCredential` field into an array of credentials.
+ * @param {VerifiablePresentation} presentation - The presentation to read from.
+ * @returns {SignedVerifiableCredential[]} The embedded credentials (empty if none).
+ */
+const getCredentials = (presentation: VerifiablePresentation): SignedVerifiableCredential[] => {
+  const vc = presentation?.verifiableCredential;
+  if (!vc) {
+    return [];
+  }
+  return Array.isArray(vc) ? vc : [vc];
+};
+
+/**
+ * Reads the `id` from an object-or-string value (e.g. issuer/holder/subject id).
+ * @param {string | Record<string, unknown> | undefined} value - The value to read.
+ * @returns {string | undefined} The id, or undefined if absent.
+ */
+const readId = (value: string | Record<string, unknown> | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  return typeof value === 'string' ? value : (value.id as string | undefined);
+};
+
+/**
+ * Extracts the DID from a verification method id by stripping the fragment.
+ * e.g. `did:key:zAbc#zAbc` -> `did:key:zAbc`.
+ * @param {string | undefined} id - The verification method id.
+ * @returns {string | undefined} The controller DID, or undefined.
+ */
+const getDidFromId = (id: string | undefined): string | undefined =>
+  id ? id.split('#')[0] : undefined;
+
+/**
+ * Returns the first credentialSubject of a credential (credentialSubject may be
+ * a single object or an array).
+ * @param {SignedVerifiableCredential} credential - The credential to read from.
+ * @returns {Record<string, unknown> | undefined} The first subject, if any.
+ */
+const getFirstSubject = (
+  credential: SignedVerifiableCredential,
+): Record<string, unknown> | undefined => {
+  const subject = credential?.credentialSubject;
+  return Array.isArray(subject) ? subject[0] : subject;
+};
+
+/**
+ * Determines whether a credential carries a TransferableRecords credential
+ * status. Such credentials are controlled on-chain via their token registry, so
+ * their possession/holder binding is proven by token ownership rather than by a
+ * Verifiable Presentation — wrapping them in a VP is therefore disallowed.
+ * @param {SignedVerifiableCredential} credential - The credential to inspect.
+ * @returns {boolean} True if any credentialStatus is of type TransferableRecords.
+ */
+const hasTransferableRecords = (credential: SignedVerifiableCredential): boolean => {
+  const status = credential?.credentialStatus;
+  if (!status) {
+    return false;
+  }
+  const statuses = Array.isArray(status) ? status : [status];
+  return statuses.some((entry) => entry?.type === 'TransferableRecords');
+};
+
+/**
+ * Throws if any credential in the list carries a TransferableRecords status.
+ * @param {SignedVerifiableCredential[]} credentials - The credentials to check.
+ * @throws {Error} If a TransferableRecords credential is found.
+ */
+const assertNoTransferableRecords = (credentials: SignedVerifiableCredential[]): void => {
+  const index = credentials.findIndex(hasTransferableRecords);
+  if (index !== -1) {
+    throw new Error(
+      `credential at index ${index} has a "TransferableRecords" credentialStatus and cannot be ` +
+        `included in a Verifiable Presentation. Transferable records are controlled on-chain via ` +
+        `their token registry; present them through their token ownership instead.`,
+    );
+  }
+};
+
+// Selective-disclosure cryptosuites whose base credentials must be derived
+// before they can be verified / presented.
+const SD_CREDENTIAL_CRYPTOSUITES = ['ecdsa-sd-2023', 'bbs-2023'];
+
+/**
+ * Determines whether a credential is a base (non-derived) selective-disclosure
+ * credential — i.e. signed with an SD cryptosuite but not yet derived, so it is
+ * not directly verifiable.
+ * @param {SignedVerifiableCredential} credential - The credential to inspect.
+ * @returns {Promise<boolean>} True if it is a base SD credential.
+ */
+const isBaseSdCredential = async (credential: SignedVerifiableCredential): Promise<boolean> => {
+  const cryptosuite = credential?.proof?.cryptosuite as string | undefined;
+  if (!cryptosuite || !SD_CREDENTIAL_CRYPTOSUITES.includes(cryptosuite)) {
+    return false;
+  }
+  return !(await isDerived(credential));
+};
+
+/**
+ * Derives a base selective-disclosure credential revealing ALL of its fields
+ * (full disclosure), producing a directly-verifiable derived credential.
+ * @param {SignedVerifiableCredential} credential - The base SD credential.
+ * @param {DocumentLoader} documentLoader - JSON-LD document loader.
+ * @returns {Promise<SignedVerifiableCredential>} The fully-disclosed derived credential.
+ * @throws {Error} If derivation fails.
+ */
+const deriveFullDisclosure = async (
+  credential: SignedVerifiableCredential,
+  documentLoader: DocumentLoader,
+): Promise<SignedVerifiableCredential> => {
+  // Reveal every top-level field (pointing at an object reveals it in full).
+  const pointers = Object.keys(credential)
+    .filter((key) => key !== '@context' && key !== 'proof')
+    .map((key) => `/${key}`);
+  const result = await deriveCredential(credential, pointers, { documentLoader });
+  if (result.error || !result.derived) {
+    throw new Error(`failed to derive credential for full disclosure: ${result.error}`);
+  }
+  return result.derived;
+};
+
+// Default Verifiable Presentation lifetime when the caller does not specify one.
+const DEFAULT_VP_LIFETIME_SECONDS = 300; // 5 minutes
+
+// The VP-level expiry fields (validFrom/validUntil, issuanceDate/expirationDate) are only
+// defined for CREDENTIALS in the VC contexts, not for a VerifiablePresentation. Stamping
+// them on the VP without defining them makes the signature canonicalization drop them under
+// strict JSON-LD safe mode (jsonld ≥ 9). This inline context defines them (using the
+// standard credentials-vocab IRIs) so the VP proof covers them. Added to the VP @context.
+const CREDENTIALS_VOCAB = 'https://www.w3.org/2018/credentials#';
+const XSD_DATETIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
+const dateTerm = (name: string) => ({
+  '@id': `${CREDENTIALS_VOCAB}${name}`,
+  '@type': XSD_DATETIME,
+});
+const VP_EXPIRY_CONTEXT = {
+  validFrom: dateTerm('validFrom'),
+  validUntil: dateTerm('validUntil'),
+  issuanceDate: dateTerm('issuanceDate'),
+  expirationDate: dateTerm('expirationDate'),
+} as const;
+
+/**
+ * Reads a credential's temporal validity bounds, supporting both v2.0
+ * (validFrom/validUntil) and v1.1 (issuanceDate/expirationDate).
+ */
+const getValidityBounds = (doc: Record<string, unknown>): { from?: string; until?: string } => ({
+  from: (doc.validFrom ?? doc.issuanceDate) as string | undefined,
+  until: (doc.validUntil ?? doc.expirationDate) as string | undefined,
+});
+
+/**
+ * Asserts a credential is temporally valid at `now` (not expired, not future-dated).
+ * @throws {Error} If the credential has expired or is not yet valid.
+ */
+const assertCredentialTemporallyValid = (
+  credential: SignedVerifiableCredential,
+  index: number,
+  now: Date,
+): void => {
+  const { from, until } = getValidityBounds(credential);
+  if (until && now > new Date(until)) {
+    throw new Error(`credential at index ${index} has expired (${until}).`);
+  }
+  if (from && now < new Date(from)) {
+    throw new Error(`credential at index ${index} is not yet valid (${from}).`);
+  }
+};
+
+/**
+ * Asserts a credential has not been revoked/suspended via its credentialStatus.
+ * Credentials with no status are treated as not revoked. Requires a document
+ * loader to fetch the status list.
+ * @throws {Error} If the credential is revoked/suspended or its status can't be checked.
+ */
+const assertCredentialNotRevoked = async (
+  credential: SignedVerifiableCredential,
+  index: number,
+  documentLoader: DocumentLoader,
+): Promise<void> => {
+  const status = credential.credentialStatus;
+  if (!status) {
+    return;
+  }
+  const statuses = Array.isArray(status) ? status : [status];
+  for (const entry of statuses) {
+    // TransferableRecords are blocked earlier; skip any that slipped through.
+    if (!entry?.type || entry.type === 'TransferableRecords') {
+      continue;
+    }
+    const result = await verifyCredentialStatus(
+      entry,
+      entry.type as Parameters<typeof verifyCredentialStatus>[1],
+      { documentLoader },
+    );
+    if (result.error) {
+      throw new Error(`credential at index ${index}: could not verify status: ${result.error}`);
+    }
+    if (result.status === true) {
+      throw new Error(
+        `credential at index ${index} has been ${result.purpose ?? 'revoked'} (credentialStatus).`,
+      );
+    }
+  }
+};
+
+/**
+ * Validates the basic structure of a Verifiable Presentation.
+ * @param {VerifiablePresentation} presentation - The presentation to validate.
+ * @param {'sign' | 'verify'} mode - Whether the presentation is being signed or verified.
+ * @throws {Error} If the presentation is structurally invalid.
+ */
+const _checkPresentation = (
+  presentation: VerifiablePresentation,
+  mode: 'sign' | 'verify' = 'verify',
+): void => {
+  if (!presentation || typeof presentation !== 'object') {
+    throw new Error('"presentation" must be an object.');
+  }
+
+  const contexts = jsonld.getValues(presentation, '@context');
+  if (contexts.length < 1) {
+    throw new Error('"@context" property is required.');
+  }
+  const firstContext = contexts[0];
+  if (firstContext !== VC_V1_URL && firstContext !== VC_V2_URL) {
+    throw new Error(
+      `The first element of '@context' must be either '${VC_V1_URL}' (v1.1) or '${VC_V2_URL}' (v2.0).`,
+    );
+  }
+
+  if (!presentation.type) {
+    throw new Error('"type" property is required.');
+  }
+  if (!jsonld.getValues(presentation, 'type').includes('VerifiablePresentation')) {
+    throw new Error('"type" must include `VerifiablePresentation`.');
+  }
+
+  // `verifiableCredential`, when present, must be a credential object or an array of them.
+  if ('verifiableCredential' in presentation) {
+    const credentials = getCredentials(presentation);
+    if (credentials.length === 0) {
+      throw new Error('"verifiableCredential" must contain at least one credential.');
+    }
+    for (const credential of credentials) {
+      if (!credential || typeof credential !== 'object') {
+        throw new Error('each "verifiableCredential" entry must be a credential object.');
+      }
+      if (mode === 'verify' && !credential.proof) {
+        throw new Error('each "verifiableCredential" entry must be signed (missing "proof").');
+      }
+    }
+  }
+
+  if (mode === 'sign' && presentation.proof) {
+    throw new Error('"proof" property is already there.');
+  }
+  if (
+    mode === 'verify' &&
+    presentation.proof &&
+    jsonld.getValues(presentation, 'proof').length > 1
+  ) {
+    throw new Error('"proof" property can only have one value.');
+  }
+};
+
+/**
+ * Checks if the input document is a raw (unsigned) Verifiable Presentation.
+ * @param {RawVerifiablePresentation | unknown} presentation - The presentation to check.
+ * @returns {boolean} True if it is a structurally valid unsigned presentation.
+ */
+export const isRawPresentation = (presentation: RawVerifiablePresentation | unknown): boolean => {
+  try {
+    _checkPresentation(presentation as VerifiablePresentation, 'sign');
+  } catch {
+    return false;
+  }
+  return typeof presentation === 'object' && !('proof' in (presentation as object));
+};
+
+/**
+ * Checks if the input document is a signed Verifiable Presentation.
+ * @param {SignedVerifiablePresentation | unknown} presentation - The presentation to check.
+ * @returns {boolean} True if it is a structurally valid presentation carrying a proof.
+ */
+export const isSignedPresentation = (
+  presentation: SignedVerifiablePresentation | unknown,
+): presentation is SignedVerifiablePresentation => {
+  try {
+    _checkPresentation(presentation as VerifiablePresentation, 'verify');
+  } catch {
+    return false;
+  }
+  return typeof presentation === 'object' && 'proof' in (presentation as object);
+};
+
+/**
+ * Builds an (unsigned) Verifiable Presentation envelope wrapping one or more
+ * Verifiable Credentials, validating every input credential first.
+ *
+ * **Strict at creation** — the presentation is only produced if EVERY credential:
+ * is signed, is **non-transferable** (no `TransferableRecords` status), has a valid
+ * issuer signature, is temporally valid (not expired / not future-dated), and is not
+ * revoked. Otherwise it throws with a clear reason and no VP is produced.
+ *
+ * The presentation is stamped with a **mandatory expiry**: `validFrom = now` and
+ * `validUntil = now + lifetime` (v2.0), or `issuanceDate`/`expirationDate` (v1.1).
+ * The lifetime is configurable and defaults to {@link DEFAULT_VP_LIFETIME_SECONDS}.
+ *
+ * @param {SignedVerifiableCredential | SignedVerifiableCredential[]} verifiableCredential -
+ *   The credential(s) to present. Each must already be signed (and, for SD suites, derived).
+ * @param {object} [options] - Options.
+ * @param {string} [options.holder] - The holder DID. Defaults to the first credential's `credentialSubject.id`.
+ * @param {string} [options.id] - An optional presentation id.
+ * @param {string | string[]} [options.type] - Extra type(s) in addition to `VerifiablePresentation`.
+ * @param {string | string[]} [options.context] - Override the `@context`.
+ * @param {'v1' | 'v2'} [options.version] - VC Data Model version of the presentation
+ *   ENVELOPE. Defaults to `'v2'` regardless of the embedded credentials' versions (each
+ *   credential keeps its own `@context`). Set `'v1'` only if a verifier requires a v1.1 VP.
+ * @param {number} [options.expiresInSeconds] - VP lifetime in seconds (from `validFrom`). Defaults to {@link DEFAULT_VP_LIFETIME_SECONDS}.
+ * @param {string} [options.validFrom] - Explicit start time (ISO). Defaults to now.
+ * @param {string} [options.validUntil] - Explicit expiry (ISO). Overrides `expiresInSeconds`.
+ * @param {boolean} [options.fullDisclosure] - When true, any base (non-derived) SD credential
+ *   is first derived revealing ALL fields, so it becomes verifiable/presentable. ⚠️ discloses
+ *   every field. Without this, a base credential fails validation and no VP is produced.
+ * @param {boolean} [options.checkHolderBinding] - When true, require every credential's
+ *   `credentialSubject.id` to equal the holder (a data-consistency check to catch bundling a
+ *   credential that isn't the holder's). This is NOT the cryptographic proof — that is
+ *   enforced at verify time (signer DID == holder == subject) via verifyPresentation.
+ * @param {Date} [options.now] - Reference time (for testing). Defaults to `new Date()`.
+ * @param {DocumentLoader} [options.documentLoader] - Loader used to verify signatures/revocation.
+ * @returns {Promise<RawVerifiablePresentation>} The validated, expiry-stamped presentation.
+ * @throws {Error} If any credential is invalid (with the reason and its index).
+ */
+export const createPresentation = async (
+  verifiableCredential: SignedVerifiableCredential | SignedVerifiableCredential[],
+  options?: {
+    holder?: string;
+    id?: string;
+    type?: string | string[];
+    context?: string | string[];
+    version?: 'v1' | 'v2';
+    expiresInSeconds?: number;
+    validFrom?: string;
+    validUntil?: string;
+    fullDisclosure?: boolean;
+    checkHolderBinding?: boolean;
+    now?: Date;
+    documentLoader?: DocumentLoader;
+  },
+): Promise<RawVerifiablePresentation> => {
+  let credentials = Array.isArray(verifiableCredential)
+    ? verifiableCredential
+    : [verifiableCredential];
+
+  if (credentials.length === 0) {
+    throw new Error('"verifiableCredential" must contain at least one credential.');
+  }
+  for (const credential of credentials) {
+    if (!credential || typeof credential !== 'object' || !credential.proof) {
+      throw new Error('each credential must be a signed credential object (with a "proof").');
+    }
+  }
+
+  const now = options?.now ?? new Date();
+  const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
+
+  // Optionally auto-derive any base (non-derived) SD credential with full disclosure so it
+  // becomes verifiable. Done before the checks below (a derived cred that still carries a
+  // TransferableRecords status is then caught).
+  if (options?.fullDisclosure) {
+    credentials = await Promise.all(
+      credentials.map(async (credential) =>
+        (await isBaseSdCredential(credential))
+          ? await deriveFullDisclosure(credential, documentLoader)
+          : credential,
+      ),
+    );
+  }
+
+  // Transferable records are controlled on-chain and must not be presented via a VP.
+  assertNoTransferableRecords(credentials);
+
+  // Strict validation: every credential must be genuine, temporally valid, and unrevoked.
+  for (let i = 0; i < credentials.length; i++) {
+    const verification = await verifyCredential(credentials[i], { documentLoader });
+    if (!verification.verified) {
+      throw new Error(`credential at index ${i} is not valid: ${verification.error}`);
+    }
+    assertCredentialTemporallyValid(credentials[i], i, now);
+    await assertCredentialNotRevoked(credentials[i], i, documentLoader);
+  }
+
+  // The presentation ENVELOPE defaults to VC Data Model v2.0, independent of the embedded
+  // credentials' versions (each credential keeps its own @context). Override with `version`.
+  const isV2 = options?.version !== 'v1';
+  const modelContext = isV2 ? VC_V2_URL : VC_V1_URL;
+
+  // Base context + an inline definition of the expiry terms so the stamped
+  // validFrom/validUntil (or issuanceDate/expirationDate) survive strict JSON-LD safe mode.
+  const baseContext = options?.context ?? [modelContext, DATA_INTEGRITY_V2_URL];
+  const context = [
+    ...(Array.isArray(baseContext) ? baseContext : [baseContext]),
+    VP_EXPIRY_CONTEXT,
+  ];
+
+  const extraTypes = options?.type
+    ? Array.isArray(options.type)
+      ? options.type
+      : [options.type]
+    : [];
+  const type = [
+    'VerifiablePresentation',
+    ...extraTypes.filter((t) => t !== 'VerifiablePresentation'),
+  ];
+
+  // Default the holder to the subject of the first credential, when present.
+  const holder = options?.holder ?? readId(getFirstSubject(credentials[0]));
+
+  // Optional holder-binding CONSISTENCY check (data-level, not cryptographic): every
+  // credential must be about the holder. Catches bundling a credential that isn't the
+  // holder's, or mixing credentials from different subjects. The cryptographic proof
+  // (signer DID == holder == subject) is enforced later by verifyPresentation.
+  if (options?.checkHolderBinding) {
+    if (!holder) {
+      throw new Error(
+        'holder binding requested but no "holder" is set and no credentialSubject.id to derive it from.',
+      );
+    }
+    for (let i = 0; i < credentials.length; i++) {
+      const subjectId = readId(getFirstSubject(credentials[i]));
+      if (!subjectId) {
+        throw new Error(
+          `credential at index ${i} has no "credentialSubject.id", so it cannot be bound to the holder.`,
+        );
+      }
+      if (subjectId !== holder) {
+        throw new Error(
+          `credential at index ${i} is about "${subjectId}", which does not match the holder ` +
+            `"${holder}".`,
+        );
+      }
+    }
+  }
+
+  // Mandatory expiry stamp.
+  const validFrom = options?.validFrom ?? now.toISOString();
+  const validUntil =
+    options?.validUntil ??
+    new Date(
+      new Date(validFrom).getTime() +
+        (options?.expiresInSeconds ?? DEFAULT_VP_LIFETIME_SECONDS) * 1000,
+    ).toISOString();
+
+  const presentation: RawVerifiablePresentation = {
+    '@context': context,
+    type,
+    verifiableCredential: credentials,
+  };
+  if (options?.id) {
+    presentation.id = options.id;
+  }
+  if (holder) {
+    presentation.holder = holder;
+  }
+  // v2.0 uses validFrom/validUntil; v1.1 uses issuanceDate/expirationDate.
+  if (isV2) {
+    presentation.validFrom = validFrom;
+    presentation.validUntil = validUntil;
+  } else {
+    presentation.issuanceDate = validFrom;
+    presentation.expirationDate = validUntil;
+  }
+  return presentation;
+};
+
+/**
+ * Signs a Verifiable Presentation with a holder-binding proof.
+ *
+ * The proof uses the plain (non-selective-disclosure) `ecdsa-rdfc-2019`
+ * cryptosuite, signing the whole envelope. It reuses the same ECDSA (P-256)
+ * Multikey used for `ecdsa-sd-2023` credentials — the holder's signing key is
+ * independent of the cryptosuites used by the embedded credentials, which may be
+ * anything (`ecdsa-sd-2023`, `bbs-2023`, ...).
+ *
+ * The selective-disclosure suites (`ecdsa-sd-2023`, `bbs-2023`) and the
+ * deprecated `BbsBlsSignature2020` are rejected for the presentation proof.
+ *
+ * The proof purpose depends on whether a `challenge` is supplied:
+ * - **with `challenge`** → `proofPurpose: authentication` (holder authenticating for a
+ *   specific request; carries `challenge` and optional `domain`; enables replay/relay
+ *   protection when the verifier checks them).
+ * - **without `challenge`** → `proofPurpose: assertionMethod` (the holder asserts the
+ *   bundle; NO `challenge`/`domain` fields). This proves the holder's key signed the VP
+ *   and its integrity, but is NOT anti-replay — a captured VP can be re-presented.
+ *
+ * @param {RawVerifiablePresentation} presentation - The unsigned presentation.
+ * @param {PrivateKeyPair} keyPair - The holder's ECDSA (P-256) Multikey key pair.
+ * @param {object} [options] - Signing options.
+ * @param {string} [options.challenge] - Verifier-supplied challenge. When present, an
+ *   `authentication` proof is produced (prevents replay); when omitted, an
+ *   `assertionMethod` proof with no challenge/domain is produced.
+ * @param {string} [options.domain] - Verifier domain. Requires `challenge` (audience
+ *   binding only applies to an authentication proof).
+ * @param {DocumentLoader} [options.documentLoader] - Custom JSON-LD document loader.
+ * @param {PresentationProofSuite} [options.cryptoSuite] - Presentation proof suite. Defaults to 'ecdsa-rdfc-2019'.
+ * @param {boolean} [options.checkHolderBinding] - When true, refuse to sign unless the
+ *   signing key's DID matches the presentation's `holder` and every `credentialSubject.id`.
+ *   Catches signing with the wrong key at sign time (otherwise only caught by the verifier).
+ * @returns {Promise<PresentationSigningResult>} The signed presentation or an error.
+ */
+export const signPresentation = async (
+  presentation: RawVerifiablePresentation,
+  keyPair: PrivateKeyPair,
+  options?: {
+    challenge?: string;
+    domain?: string;
+    documentLoader?: DocumentLoader;
+    cryptoSuite?: PresentationProofSuite;
+    checkHolderBinding?: boolean;
+  },
+): Promise<PresentationSigningResult> => {
+  try {
+    const cryptoSuite = options?.cryptoSuite ?? PRESENTATION_PROOF_CRYPTOSUITE;
+
+    if (UNSUPPORTED_PROOF_SUITES.includes(cryptoSuite)) {
+      return {
+        error:
+          `"${cryptoSuite}" cannot sign a Verifiable Presentation. Selective-disclosure ` +
+          `suites cannot cover the "verifiableCredential" @graph, and BbsBlsSignature2020 is ` +
+          `deprecated. Use "${PRESENTATION_PROOF_CRYPTOSUITE}"; embedded credentials may still ` +
+          `use any suite.`,
+      };
+    }
+    if (cryptoSuite !== PRESENTATION_PROOF_CRYPTOSUITE) {
+      return { error: `"${cryptoSuite}" is not supported for signing a presentation.` };
+    }
+
+    // A `challenge` yields an authentication proof; omitting it yields an assertion
+    // proof (no challenge/domain). `domain` only makes sense with a challenge.
+    const challenge = options?.challenge;
+    if (options?.domain && !challenge) {
+      return {
+        error: '"domain" requires a "challenge" (audience binding needs an authentication proof).',
+      };
+    }
+
+    if (!keyPair) {
+      return { error: 'a signing key (keyPair) is required to sign a presentation.' };
+    }
+    _checkPresentation(presentation, 'sign');
+    _checkKeyPair(keyPair);
+
+    const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
+
+    // Transferable records are controlled on-chain and must not be presented via a VP.
+    assertNoTransferableRecords(getCredentials(presentation));
+
+    // Optionally refuse to sign with the wrong key: the signing key's DID must match the
+    // holder and every credentialSubject.id. Caught here at sign time (a verifier with
+    // checkHolderBinding would otherwise catch it later).
+    if (options?.checkHolderBinding) {
+      const signerDid = keyPair.controller ?? getDidFromId(keyPair.id);
+      const holder = readId(presentation.holder);
+      if (holder && signerDid && holder !== signerDid) {
+        return {
+          error: `the signing key "${signerDid}" does not match the presentation holder "${holder}".`,
+        };
+      }
+      const owner = holder ?? signerDid;
+      const credentials = getCredentials(presentation);
+      for (let i = 0; i < credentials.length; i++) {
+        const subjectId = readId(getFirstSubject(credentials[i]));
+        if (subjectId && owner && subjectId !== owner) {
+          return {
+            error:
+              `credential at index ${i} is about "${subjectId}", which does not match the ` +
+              `signing key / holder "${owner}".`,
+          };
+        }
+      }
+    }
+
+    // Load the ECDSA Multikey into a signer. A non-ECDSA key (e.g. a BBS Multikey)
+    // fails here — surface a clear, actionable error rather than the raw failure.
+    let signer;
+    try {
+      const ecdsaKeyPair = keyPair as EcdsaSd2023PrivateKeyPair;
+      const keyPairInstance = await EcdsaMultikey.from({ ...ecdsaKeyPair });
+      signer = keyPairInstance.signer();
+    } catch {
+      return {
+        error:
+          `An ECDSA (P-256) Multikey is required to sign a presentation with ` +
+          `"${PRESENTATION_PROOF_CRYPTOSUITE}". The provided key could not be loaded as an ECDSA key ` +
+          `(BBS keys cannot produce a plain presentation proof).`,
+      };
+    }
+
+    // authentication (with challenge) vs assertionMethod (no challenge/domain)
+    const purpose = challenge
+      ? new AuthenticationProofPurpose({ challenge, domain: options?.domain })
+      : new AssertionProofPurpose();
+
+    const signed = await jsonldSignatures.sign(presentation, {
+      suite: new DataIntegrityProof({
+        signer,
+        cryptosuite: ecdsaRdfc2019Cryptosuite.cryptosuite,
+      }),
+      purpose,
+      documentLoader,
+    });
+
+    return { signed: signed as SignedVerifiablePresentation };
+  } catch (err: unknown) {
+    if (!(err instanceof Error)) {
+      return { error: 'An error occurred while signing the presentation.' };
+    }
+    return { error: err.message };
+  }
+};
+
+/**
+ * Verifies a Verifiable Presentation.
+ *
+ * Verification succeeds only when every embedded credential verifies AND, if the
+ * presentation carries a holder proof, that proof verifies too. Each embedded
+ * credential is verified independently via {@link verifyCredential}, so a single
+ * presentation may mix cryptosuites and VC data-model versions.
+ *
+ * @param {VerifiablePresentation} presentation - The presentation to verify.
+ * @param {object} [options] - Verification options.
+ * @param {string} [options.challenge] - The challenge the verifier issued. REQUIRED
+ *   when the presentation carries an `authentication` proof — verification fails without
+ *   it. Not needed for an `assertionMethod` proof (which has no challenge). The proof's
+ *   own embedded challenge is never trusted (that would allow replay).
+ * @param {string} [options.domain] - Expected domain, checked against the proof.
+ * @param {boolean} [options.requireProof] - When true, a presentation WITHOUT a
+ *   holder proof fails verification. Set this when the verifier needs holder
+ *   binding, so an unsigned bundle is not silently accepted. Default false
+ *   (unsigned presentations verify on credential authenticity alone).
+ * @param {boolean} [options.checkHolderBinding] - When true, cryptographically
+ *   require that the presenter owns the credentials: the presentation must be
+ *   signed, and the signing key's DID must equal the holder and every credential's
+ *   `credentialSubject.id`. Fails on an unsigned presentation (ownership cannot be
+ *   proven without a signature).
+ * @param {number} [options.maxLifetimeSeconds] - When set, reject a presentation whose
+ *   own lifetime (validUntil − validFrom) exceeds this — so a holder can't defeat the
+ *   expiry with a far-future `validUntil`. (Expiry itself is always checked.)
+ * @param {Date} [options.now] - Reference time for expiry checks (for testing). Defaults to now.
+ * @param {DocumentLoader} [options.documentLoader] - Custom JSON-LD document loader.
+ * @returns {Promise<PresentationVerificationResult>} The aggregated verification result.
+ */
+export const verifyPresentation = async (
+  presentation: VerifiablePresentation,
+  options?: {
+    challenge?: string;
+    domain?: string;
+    requireProof?: boolean;
+    checkHolderBinding?: boolean;
+    maxLifetimeSeconds?: number;
+    now?: Date;
+    documentLoader?: DocumentLoader;
+  },
+): Promise<PresentationVerificationResult> => {
+  try {
+    _checkPresentation(presentation, 'verify');
+    const documentLoader = options?.documentLoader ?? (await getDocumentLoader());
+
+    const vpNow = options?.now ?? new Date();
+
+    // 0. Temporal validity of the presentation itself (expiry + optional max lifetime).
+    let expiryError: string | undefined;
+    {
+      const { from, until } = getValidityBounds(presentation);
+      if (until && vpNow > new Date(until)) {
+        expiryError = `presentation has expired (validUntil ${until}).`;
+      } else if (from && vpNow < new Date(from)) {
+        expiryError = `presentation is not yet valid (validFrom ${from}).`;
+      } else if (options?.maxLifetimeSeconds != null && from && until) {
+        const lifetimeSeconds = (new Date(until).getTime() - new Date(from).getTime()) / 1000;
+        if (lifetimeSeconds > options.maxLifetimeSeconds) {
+          expiryError =
+            `presentation lifetime (${lifetimeSeconds}s) exceeds the maximum allowed ` +
+            `(${options.maxLifetimeSeconds}s).`;
+        }
+      }
+    }
+
+    // 1. Verify each embedded credential independently (any suite / version). Expiry is
+    //    enforced here too (verifyCredential only warns) so that a VP is rejected for an
+    //    expired embedded credential — consistent with createPresentation's strict creation.
+    const credentials = getCredentials(presentation);
+    const credentialResults: CredentialVerificationResult[] = [];
+    for (let i = 0; i < credentials.length; i++) {
+      let result = await verifyCredential(credentials[i], { documentLoader });
+      if (result.verified) {
+        try {
+          assertCredentialTemporallyValid(credentials[i], i, vpNow);
+        } catch (err) {
+          result = { verified: false, error: err instanceof Error ? err.message : 'expired' };
+        }
+      }
+      credentialResults.push({ ...result, credentialIndex: i });
+    }
+    const allCredentialsVerified =
+      credentials.length > 0 && credentialResults.every((r) => r.verified);
+
+    // 2. Verify the holder-binding proof, if present.
+    let presentationResult: PresentationVerificationResult['presentationResult'];
+    if (presentation.proof) {
+      const proof = jsonld.getValues(presentation, 'proof')[0];
+      const proofType = proof.type as ProofType;
+      const proofCryptosuite = proof.cryptosuite as string | undefined;
+      if (
+        proofType !== 'DataIntegrityProof' ||
+        proofCryptosuite !== PRESENTATION_PROOF_CRYPTOSUITE
+      ) {
+        presentationResult = {
+          verified: false,
+          error:
+            `Presentation proof type "${proofType}"` +
+            (proofCryptosuite ? ` (cryptosuite "${proofCryptosuite}")` : '') +
+            ` is not supported. Only "${PRESENTATION_PROOF_CRYPTOSUITE}" holder proofs are supported.`,
+        };
+      } else {
+        const proofPurpose = proof.proofPurpose as string | undefined;
+        const runVerify = async (purpose: unknown) =>
+          jsonldSignatures.verify(presentation, {
+            suite: new DataIntegrityProof({ cryptosuite: ecdsaRdfc2019Cryptosuite.cryptosuite }),
+            purpose,
+            documentLoader,
+          });
+        const toResult = (result: {
+          verified: boolean;
+          error?: { errors?: { message?: string }[] };
+        }) =>
+          result.verified
+            ? { verified: true }
+            : {
+                verified: false,
+                error:
+                  result.error?.errors?.[0]?.message ?? 'Presentation proof verification error.',
+              };
+
+        if (proofPurpose === 'authentication') {
+          // The challenge MUST be supplied by the caller (the verifier), not read from
+          // the proof — trusting the proof's own challenge would defeat replay protection.
+          const challenge = options?.challenge;
+          const domain = options?.domain;
+          if (!challenge) {
+            presentationResult = {
+              verified: false,
+              error:
+                'A caller-supplied "challenge" is required to verify an authentication ' +
+                'presentation proof. Pass the challenge the verifier issued; the value embedded ' +
+                'in the proof is not trusted.',
+            };
+          } else {
+            presentationResult = toResult(
+              await runVerify(new AuthenticationProofPurpose({ challenge, domain })),
+            );
+          }
+        } else if (proofPurpose === 'assertionMethod') {
+          // Assertion proof: no challenge/domain. Proves the holder's key signed the VP
+          // (integrity + control at signing time) but is NOT anti-replay.
+          presentationResult = toResult(await runVerify(new AssertionProofPurpose()));
+        } else {
+          presentationResult = {
+            verified: false,
+            error: `Presentation proof purpose "${proofPurpose}" is not supported.`,
+          };
+        }
+      }
+    }
+
+    // 3. Optional holder binding: cryptographically prove the presenter owns the
+    //    credentials. This requires that the VP is signed AND that the signing key's
+    //    DID equals the holder equals every credentialSubject.id. Without a proof,
+    //    ownership cannot be established, so the check fails.
+    let holderBindingError: string | undefined;
+    if (options?.checkHolderBinding) {
+      if (!presentation.proof) {
+        holderBindingError =
+          'holder binding requires a signed presentation (no "proof" is present, so ownership ' +
+          'cannot be proven).';
+      } else if (presentationResult?.verified !== true) {
+        holderBindingError =
+          'holder binding requires a valid presentation proof, but the proof did not verify.';
+      } else {
+        // The DID that signed the presentation (verificationMethod without its fragment).
+        const signerDid = getDidFromId(presentation.proof.verificationMethod as string | undefined);
+        const holder = readId(presentation.holder);
+
+        if (!signerDid) {
+          holderBindingError = 'the presentation proof has no "verificationMethod" to bind to.';
+        } else if (holder && holder !== signerDid) {
+          // The presenter's signing key must belong to the declared holder.
+          holderBindingError =
+            `the presentation was signed by "${signerDid}", which does not match the ` +
+            `declared holder "${holder}".`;
+        } else {
+          // Every credential must be about the presenter (the signer / holder).
+          const owner = holder ?? signerDid;
+          for (let i = 0; i < credentials.length; i++) {
+            const subjectId = readId(getFirstSubject(credentials[i]));
+            if (!subjectId) {
+              holderBindingError =
+                `credential at index ${i} has no "credentialSubject.id", so it cannot be bound ` +
+                `to the holder.`;
+              break;
+            }
+            if (subjectId !== owner) {
+              holderBindingError =
+                `credentialSubject.id ("${subjectId}") of credential at index ${i} does not ` +
+                `match the presentation holder/signer ("${owner}").`;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    // A verifier that needs holder binding can require a proof to be present.
+    const missingRequiredProof = options?.requireProof && !presentation.proof;
+
+    const proofVerified = presentation.proof ? presentationResult?.verified === true : true;
+    const verified =
+      allCredentialsVerified &&
+      proofVerified &&
+      !holderBindingError &&
+      !missingRequiredProof &&
+      !expiryError;
+
+    const aggregate: PresentationVerificationResult = {
+      verified,
+      credentialResults,
+    };
+    if (presentationResult) {
+      aggregate.presentationResult = presentationResult;
+    }
+    if (!verified) {
+      aggregate.error =
+        expiryError ??
+        (missingRequiredProof
+          ? 'a holder proof is required ("requireProof"), but the presentation is not signed.'
+          : (holderBindingError ??
+            presentationResult?.error ??
+            credentialResults.find((r) => !r.verified)?.error ??
+            (credentials.length === 0
+              ? 'presentation contains no verifiable credentials.'
+              : 'presentation verification failed.')));
+    }
+    return aggregate;
+  } catch (err: unknown) {
+    if (!(err instanceof Error)) {
+      return { verified: false, error: 'An error occurred while verifying the presentation.' };
+    }
+    return { verified: false, error: err.message };
+  }
+};

--- a/packages/w3c-vc/src/lib/types.ts
+++ b/packages/w3c-vc/src/lib/types.ts
@@ -91,6 +91,53 @@ export type SignedVerifiableCredential = {
 
 export type RawVerifiableCredential = Omit<SignedVerifiableCredential, 'proof'>;
 
+// A Verifiable Presentation is an envelope that wraps one or more Verifiable
+// Credentials. The embedded credentials each keep their own proof (and may use
+// different cryptosuites / VC data-model versions); the presentation may
+// additionally carry a single holder-binding proof over the whole envelope.
+export type RawVerifiablePresentation = {
+  '@context': string | (string | Record<string, any>)[];
+  type: string | string[];
+  id?: string;
+  holder?: string | Record<string, any>;
+  verifiableCredential?: SignedVerifiableCredential | SignedVerifiableCredential[];
+} & Record<string, any>;
+
+export type SignedVerifiablePresentation = RawVerifiablePresentation & {
+  proof: Proof;
+};
+
+// Cryptosuite used for a presentation's holder-binding proof. Selective-disclosure
+// suites cannot cover the `verifiableCredential` @graph, so only the plain
+// `ecdsa-rdfc-2019` suite is supported (reusing the ECDSA Multikey used for
+// `ecdsa-sd-2023` credentials).
+export type PresentationProofSuite = 'ecdsa-rdfc-2019';
+
+export type VerifiablePresentation = SignedVerifiablePresentation | RawVerifiablePresentation;
+
+// Result of signing a presentation
+export interface PresentationSigningResult {
+  signed?: SignedVerifiablePresentation; // The signed presentation, if successful
+  error?: string; // The error message, if an error occurred
+}
+
+// Per-credential verification outcome within a presentation
+export interface CredentialVerificationResult extends VerificationResult {
+  credentialIndex: number; // Index of the credential within verifiableCredential
+}
+
+// Result of verifying a presentation. `verified` is true only when the holder
+// proof (if any) AND every embedded credential verify successfully.
+export interface PresentationVerificationResult {
+  verified: boolean;
+  error?: string;
+  // Verification outcome of the presentation's own holder-binding proof.
+  // Undefined when the presentation carries no proof (unsigned envelope).
+  presentationResult?: VerificationResult;
+  // Verification outcome of each embedded verifiable credential.
+  credentialResults?: CredentialVerificationResult[];
+}
+
 export type CryptoSuiteName = 'BbsBlsSignature2020' | 'bbs-2023' | 'ecdsa-sd-2023';
 
 export type ProofType = 'BbsBlsSignature2020' | 'BbsBlsSignatureProof2020' | 'DataIntegrityProof';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, signing, and verifying W3C Verifiable Presentations.
  * Exposed presentation helpers and type-guards via the public API, including holder-binding, challenge/domain, and VP/embedded-credential expiry handling.
  * Added new TypeScript types for presentation structures and signing/verification results.
  * Added Verifiable Presentation documentation covering requirements, signing/verification modes, and validation rules.
* **Tests**
  * Added comprehensive test coverage for creation, signing, verification, expiry, disclosure behavior, and holder-binding scenarios.
* **Documentation**
  * Added repository guidance for maintainers and detailed VP/DCAP behavioral requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->