### PR TITLE
fix: validate credentialStatus format only at sign, not verify

### DIFF
--- a/packages/w3c-vc/src/lib/helper/index.ts
+++ b/packages/w3c-vc/src/lib/helper/index.ts
@@ -321,8 +321,15 @@ export function _checkCredential<T extends VerifiableCredential>(
     }
   }
 
-  // Validate credentialStatus field if present
-  assertCredentialStatuses(credential, mode);
+  // Validate the credentialStatus field FORMAT only when signing. At verify time the
+  // credential status is the concern of the dedicated status verifier (verifyCredentialStatus):
+  // a malformed status field (e.g. a non-integer tokenNetwork.chainId) must surface there as a
+  // status problem, NOT make the credential look unsigned or fail signature integrity. Note
+  // that _checkCredential(mode: 'verify') is reached by isSignedDocument() and the
+  // DataIntegrity verifiers, so throwing here would mis-attribute a status error to those.
+  if (mode === 'sign') {
+    assertCredentialStatuses(credential, mode);
+  }
 
   // Validate that certain fields, if present, are objects with a type property
   for (const prop of mustHaveType) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential verification by routing credential status validation through the dedicated status verifier.
  * Prevented status-related errors from being incorrectly reported as overall credential or signature integrity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->